### PR TITLE
Add a command to run a command for each match

### DIFF
--- a/sr/comp/cli/command_line.py
+++ b/sr/comp/cli/command_line.py
@@ -8,6 +8,7 @@ from . import (
     awards,
     delay,
     deploy,
+    for_each_match,
     import_schedule,
     knocked_out_teams,
     lighting_controller,
@@ -48,6 +49,7 @@ def argument_parser():
     awards.add_subparser(subparsers)
     delay.add_subparser(subparsers)
     deploy.add_subparser(subparsers)
+    for_each_match.add_subparser(subparsers)
     import_schedule.add_subparser(subparsers)
     knocked_out_teams.add_subparser(subparsers)
     list_midi_ports.add_subparser(subparsers)

--- a/sr/comp/cli/for_each_match.py
+++ b/sr/comp/cli/for_each_match.py
@@ -1,0 +1,115 @@
+"""
+Run a command for each of the given matches.
+
+The matches can be specified as a comma-separated list and/or dash-separated
+ranges. The commands will be run in the numeric order of matches (rather than
+the given order) and only once per match.
+
+Where a compstate has multiple arenas the command will be run for each arena, in
+the order the arenas are defined within the compstate. Alternatively a specific
+arena can be specified to limit the commands to matches in that arena.
+
+A number of placeholders are available for use in your command, so you can
+control how information about each match is passed to the command. The TLAS
+placeholder will always include enough entries for every zone in the arena,
+using '-' to represent an empty zone.
+"""
+
+import argparse
+from typing import Callable, Dict, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sr.comp.match_period import Match
+
+
+def get_tlas(match: 'Match') -> str:
+    return ' '.join(
+        x if x is not None else '-'
+        for x in match.teams
+    )
+
+
+PLACEHOLDERS = {
+    'ARENA': lambda x: x.arena,
+    'NUMBER': lambda x: str(x.num),
+    'TLAS': get_tlas,
+    'TYPE': lambda x: str(x.type.value),
+}  # type: Dict[str, Callable[[Match], str]]
+
+
+class PlaceholderExpander:
+    def __init__(self, match: 'Match') -> None:
+        self.match = match
+
+    def __getitem__(self, key: str) -> str:
+        return PLACEHOLDERS[key](self.match)
+
+
+def replace_placeholders(match: 'Match', command: List[str]) -> List[str]:
+    expander = PlaceholderExpander(match)
+    return [x.format_map(expander) for x in command]
+
+
+def command(args):
+    import subprocess
+    from sr.comp.comp import SRComp
+    from .deploy import print_fail
+
+    compstate = SRComp(args.compstate)
+
+    if args.arena:
+        if args.arena not in compstate.arenas:
+            print("{} is not a valid arena, choose from {}".format(
+                args.arena,
+                ", ".join(compstate.arenas.keys()),
+            ))
+
+    try:
+        for match_number in sorted(args.matches):
+            for arena, match in compstate.schedule.matches[match_number].items():
+                if args.arena not in (arena, None):
+                    continue
+
+                command = replace_placeholders(match, args.command)
+                subprocess.check_call(command)
+
+    except subprocess.CalledProcessError as e:
+        print_fail(str(e))
+        exit(1)
+
+
+def add_options(parser):
+    from sr.comp.matches import parse_ranges
+
+    parser.add_argument(
+        '--arena',
+        default=None,
+        help=(
+            "Limit to just one arena. By default the command is run for each "
+            "arena in turn."
+        ),
+    )
+    parser.add_argument(
+        'matches',
+        type=parse_ranges,
+        help="List of matches or match ranges, for example '1,3-5'.",
+    )
+    parser.add_argument(
+        'command',
+        nargs='+',
+        help="Command to run. Supports the following placeholders: {}".format(
+            ", ".join(PLACEHOLDERS.keys()),
+        ),
+    )
+
+
+def add_subparser(subparsers):
+    parser = subparsers.add_parser(
+        'for-each-match',
+        help="Run a command for each of the given matches.",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('compstate', help="competition state repository")
+    add_options(parser)
+    parser.set_defaults(func=command)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,28 @@
+import datetime
+from typing import Optional, Sequence
+
+from dateutil.tz import UTC
+
+from sr.comp.match_period import Match, MatchType
+from sr.comp.types import ArenaName, MatchNumber, TLA
+
+
+def build_match(
+    num: int = 0,
+    arena: str = 'main',
+    teams: Sequence[Optional[TLA]] = (),
+    start_time: datetime.datetime = datetime.datetime(2020, 1, 25, 11, 0, tzinfo=UTC),
+    end_time: datetime.datetime = datetime.datetime(2020, 1, 25, 11, 5, tzinfo=UTC),
+    type_: MatchType = MatchType.league,
+    use_resolved_ranking: bool = False,
+) -> Match:
+    return Match(
+        MatchNumber(num),
+        "Match {n}".format(n=num),
+        ArenaName(arena),
+        list(teams),
+        start_time,
+        end_time,
+        type_,
+        use_resolved_ranking,
+    )

--- a/tests/test_for_each_match.py
+++ b/tests/test_for_each_match.py
@@ -1,0 +1,33 @@
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from sr.comp.cli.for_each_match import command
+
+
+class ForEachMatchTests(unittest.TestCase):
+    longMessage = True
+    maxDiff = None
+
+    def test_smoke(self):
+        # Assumes that the dummy schedule is already properly formatted
+        compstate_path = str(Path(__file__).parent / 'dummy')
+
+        mock_settings = mock.Mock(
+            compstate=compstate_path,
+            arena=None,
+            matches=set([0, 2, 3]),
+            command=['spam', '{TYPE}:{ARENA}', '{NUMBER}|{TLAS}'],
+        )
+
+        with mock.patch('subprocess.check_call') as mock_check_call:
+            command(mock_settings)
+
+        mock_check_call.assert_has_calls([
+            mock.call(['spam', 'league:A', '0|- CLY TTN -']),
+            mock.call(['spam', 'league:B', '0|GRS QMC - -']),
+            mock.call(['spam', 'league:A', '2|ICE MFG SWI BRN']),
+            mock.call(['spam', 'league:B', '2|TBG EMM SGS GYG']),
+            mock.call(['spam', 'league:A', '3|MAI2 HSO KDE CCR']),
+            mock.call(['spam', 'league:B', '3|SCC LSS HZW MAI']),
+        ])

--- a/tests/test_for_each_match.py
+++ b/tests/test_for_each_match.py
@@ -1,8 +1,16 @@
+import contextlib
+import io
 import unittest
 from pathlib import Path
 from unittest import mock
 
-from sr.comp.cli.for_each_match import command
+from sr.comp.cli.for_each_match import (
+    command,
+    PlaceholderExpander,
+    replace_placeholders,
+)
+
+from .factories import build_match
 
 
 class ForEachMatchTests(unittest.TestCase):
@@ -31,3 +39,35 @@ class ForEachMatchTests(unittest.TestCase):
             mock.call(['spam', 'league:A', '3|MAI2 HSO KDE CCR']),
             mock.call(['spam', 'league:B', '3|SCC LSS HZW MAI']),
         ])
+
+    def test_validate_placeholders(self):
+        with contextlib.redirect_stderr(io.StringIO()) as stderr:
+            PlaceholderExpander.validate('fine')
+            self.assertEqual("", stderr.getvalue())
+
+        with contextlib.redirect_stderr(io.StringIO()) as stderr:
+            PlaceholderExpander.validate('$unknown')
+            self.assertEqual(
+                "Warning: unrecognised value '$unknown'.\n",
+                stderr.getvalue(),
+            )
+
+        with contextlib.redirect_stderr(io.StringIO()) as stderr:
+            PlaceholderExpander.validate('$TLAS')
+            self.assertEqual("", stderr.getvalue())
+
+    def test_replace_placeholders(self):
+        match = build_match(num=42, teams=['ABC', None])
+
+        command = replace_placeholders(match, [
+            'spam',
+            '{NUMBER}:{ARENA}',
+            '{TLAS}',
+            '$TLAS',
+            '$TLAS|',
+        ])
+
+        self.assertEqual(
+            ['spam', '42:main', 'ABC -', 'ABC', '-', '$TLAS|'],
+            command,
+        )


### PR DESCRIPTION
This provides a mechanism to run a command for each match, thus allowing for easy integration with systems which want match info for their own purposes but don't want to build a full Python API integration.
