### PR TITLE
Add show-league-table command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'ruamel.yaml >=0.13.0, <0.16',
         'simplejson >=3.6, <4',
         'mido >=1.1, <2',
+        'tabulate >=0.8.9, <1',
     ],
     python_requires='>=3.7',
     entry_points={

--- a/sr/comp/cli/command_line.py
+++ b/sr/comp/cli/command_line.py
@@ -19,6 +19,7 @@ from . import (
     schedule_league,
     scorer,
     shift_matches,
+    show_league_table,
     show_schedule,
     summary,
     top_match_points,
@@ -60,6 +61,7 @@ def argument_parser() -> argparse.ArgumentParser:
     schedule_league.add_subparser(subparsers)
     scorer.add_subparser(subparsers)
     shift_matches.add_subparser(subparsers)
+    show_league_table.add_subparser(subparsers)
     show_schedule.add_subparser(subparsers)
     summary.add_subparser(subparsers)
     top_match_points.add_subparser(subparsers)

--- a/sr/comp/cli/show_league_table.py
+++ b/sr/comp/cli/show_league_table.py
@@ -9,6 +9,7 @@ SORT_TYPES = {  # cli string: (sort column, sort direction)
 
 def command(settings):
     import os.path
+    from collections import Counter
 
     from sr.comp.comp import SRComp
     from tabulate import tabulate
@@ -19,17 +20,26 @@ def command(settings):
     for team in comp.teams.values():
         scores = comp.scores.league.teams[team.tla]
         league_pos = comp.scores.league.positions[team.tla]
-        league_table.append((
+        league_table.append([
             league_pos,
             scores.league_points,
             scores.game_points,
             team.tla,
             team.name,
-        ))
+        ])
 
     # sort rows
     sort_col, sort_direction = SORT_TYPES[settings.sort]
     league_table.sort(key=lambda row: row[sort_col], reverse=sort_direction)
+
+    # calculate ties
+    tie_count = Counter(rank for rank, _, _, _, _ in league_table)
+    ties = [rank for rank, count in tie_count.items() if count > 1]
+
+    # apply tie formatting
+    for team_data in league_table:
+        if team_data[0] in ties:
+            team_data[0] = f"={team_data[0]}"
 
     # Print table
     print(tabulate(

--- a/sr/comp/cli/show_league_table.py
+++ b/sr/comp/cli/show_league_table.py
@@ -1,0 +1,58 @@
+__description__ = "Show the current state of the league table"
+
+
+SORT_TYPES = {  # cli string: (sort column, sort direction)
+    'position': (0, False),
+    'game': (2, True),
+    'team': (3, False),
+}
+
+def command(settings):
+    import os.path
+    from collections import defaultdict
+    from functools import partial
+    from itertools import chain
+
+    from sr.comp.comp import SRComp
+
+    comp = SRComp(os.path.realpath(settings.compstate))
+
+    league_table = []
+    for team in comp.teams.values():
+        scores = comp.scores.league.teams[team.tla]
+        league_pos = comp.scores.league.positions[team.tla]
+        league_table.append((
+            league_pos,
+            scores.league_points,
+            scores.game_points,
+            team.tla,
+            team.name,
+        ))
+
+    # sort rows
+    sort_col, sort_direction = SORT_TYPES[settings.sort]
+    league_table.sort(key=lambda row: row[sort_col], reverse=sort_direction)
+
+    # Print header
+    print("Pos | League | Game | Team")
+    for row in league_table:
+        print(f"{row[0]:>3} | {row[1]:>6} | {row[2]:>4} | {row[3]+':':<5} {row[4]}")
+
+
+def add_subparser(subparsers):
+    parser = subparsers.add_parser(
+        'show-league-table',
+        help=__description__,
+        description=__description__,
+    )
+    parser.add_argument(
+        'compstate',
+        help="competition state repo",
+    )
+    parser.add_argument(
+        '--sort',
+        choices=SORT_TYPES.keys(),
+        default='position',
+        help="Sort table by a column",
+    )
+    parser.set_defaults(func=command)

--- a/sr/comp/cli/show_league_table.py
+++ b/sr/comp/cli/show_league_table.py
@@ -49,7 +49,7 @@ def add_subparser(subparsers):
     parser.add_argument(
         '--sort',
         choices=SORT_TYPES.keys(),
-        default='position',
+        default='rank',
         help="Sort table by a column",
     )
     parser.set_defaults(func=command)

--- a/sr/comp/cli/show_league_table.py
+++ b/sr/comp/cli/show_league_table.py
@@ -7,6 +7,7 @@ SORT_TYPES = {  # cli string: (sort column, sort direction)
     'team': (3, False),
 }
 
+
 def command(settings):
     import os.path
     from collections import Counter

--- a/sr/comp/cli/show_league_table.py
+++ b/sr/comp/cli/show_league_table.py
@@ -11,6 +11,7 @@ def command(settings):
     import os.path
 
     from sr.comp.comp import SRComp
+    from tabulate import tabulate
 
     comp = SRComp(os.path.realpath(settings.compstate))
 
@@ -30,10 +31,16 @@ def command(settings):
     sort_col, sort_direction = SORT_TYPES[settings.sort]
     league_table.sort(key=lambda row: row[sort_col], reverse=sort_direction)
 
-    # Print header
-    print("Rank | League | Game | Team")
-    for row in league_table:
-        print(f"{row[0]:>4} | {row[1]:>6} | {row[2]:>4} | {row[3]+':':<5} {row[4]}")
+    # Print table
+    print(tabulate(
+        [
+            [rank, league_points, game_points, f"{tla}: {team_name}"]
+            for rank, league_points, game_points, tla, team_name in league_table
+        ],
+        headers=["Rank", "League", "Game", "Team"],
+        tablefmt='github',
+        colalign=('center', 'center', 'center', 'left'),  # left-align team names
+    ))
 
 
 def add_subparser(subparsers):

--- a/sr/comp/cli/show_league_table.py
+++ b/sr/comp/cli/show_league_table.py
@@ -2,7 +2,7 @@ __description__ = "Show the current state of the league table"
 
 
 SORT_TYPES = {  # cli string: (sort column, sort direction)
-    'position': (0, False),
+    'rank': (0, False),
     'game': (2, True),
     'team': (3, False),
 }

--- a/sr/comp/cli/show_league_table.py
+++ b/sr/comp/cli/show_league_table.py
@@ -9,9 +9,6 @@ SORT_TYPES = {  # cli string: (sort column, sort direction)
 
 def command(settings):
     import os.path
-    from collections import defaultdict
-    from functools import partial
-    from itertools import chain
 
     from sr.comp.comp import SRComp
 

--- a/sr/comp/cli/show_league_table.py
+++ b/sr/comp/cli/show_league_table.py
@@ -12,8 +12,9 @@ def command(settings):
     import os.path
     from collections import Counter
 
-    from sr.comp.comp import SRComp
     from tabulate import tabulate
+
+    from sr.comp.comp import SRComp
 
     comp = SRComp(os.path.realpath(settings.compstate))
 

--- a/sr/comp/cli/show_league_table.py
+++ b/sr/comp/cli/show_league_table.py
@@ -31,9 +31,9 @@ def command(settings):
     league_table.sort(key=lambda row: row[sort_col], reverse=sort_direction)
 
     # Print header
-    print("Pos | League | Game | Team")
+    print("Rank | League | Game | Team")
     for row in league_table:
-        print(f"{row[0]:>3} | {row[1]:>6} | {row[2]:>4} | {row[3]+':':<5} {row[4]}")
+        print(f"{row[0]:>4} | {row[1]:>6} | {row[2]:>4} | {row[3]+':':<5} {row[4]}")
 
 
 def add_subparser(subparsers):

--- a/tests/test_show_league_table.py
+++ b/tests/test_show_league_table.py
@@ -1,0 +1,17 @@
+import os.path
+import subprocess
+import unittest
+
+
+class LeagueTableTests(unittest.TestCase):
+    def test_league_table_succeeds(self):
+        test_dir = os.path.dirname(os.path.abspath(__file__))
+        dummy_compstate = os.path.join(test_dir, 'dummy')
+
+        result = subprocess.run(
+            ['srcomp', 'show-league-table', dummy_compstate],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout)


### PR DESCRIPTION
Gives equivalent output to the league status page of the competition website

The output format is:
```
$ srcomp show-league-table --sort=rank dummy-comp 
Rank | League | Game | Team
   1 |    149 |  146 | CLY:  Collyers Sixth Form College
   2 |    107 |  116 | SCC:  Southampton City College
   3 |    105 |  112 | QEH:  Queen Elizabeth's Hospital School
   4 |    104 |   99 | PSC:  Peter Symonds College
   5 |    102 |  108 | SWI:  South Wilts Grammar School for Girls
...
```