### PR TITLE
Move to using Fabric for remote commands during deployment

### DIFF
--- a/script/typing/requirements.txt
+++ b/script/typing/requirements.txt
@@ -2,7 +2,6 @@
 mypy>=0.940
 
 types-freezegun
-types-paramiko
 types-python-dateutil
 types-requests
 types-setuptools

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
     author_email='srobo-devel@googlegroups.com',
     install_requires=[
         'python-dateutil >=2.2, <3',
-        'paramiko >=1.10, <3',
+        'Fabric >= 2.7, <3',
+        'invoke >= 1.7, <2',
         'sr.comp >=1.2, <2',
         'reportlab >=3.1.44, <3.6',
         'requests >=2.5.1, <3',


### PR DESCRIPTION
This provides the user with a more OpenSSH-like experience as it reads from their `~/.ssh/config` as expected, allowing for more advanced SSH links to the target devices.

This has some risk as it allows for more diversion between the HTTP endpoint used to check the status of the deployment and the target actually deployed onto, however this seems like a small risk in practise and the default case is unlikely to encounter this silently. More likely is that the user is on a network where they cannot easily see the HTTP endpoint and would end up bypassing that check anyway. If the mismatch becomes an issue we could always move to routing the state check through the SSH connection and/or requiring that it be opted-into.

Fixes #4.