### PR TITLE
Allow newer Fabric & Invoke

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
     author_email='srobo-devel@googlegroups.com',
     install_requires=[
         'python-dateutil >=2.2, <3',
-        'Fabric >= 2.7, <3',
-        'invoke >= 1.7, <2',
+        'Fabric >= 2.7, <4',
+        'invoke >= 1.7, <3',
         'sr.comp >=1.8, <2',
         'reportlab >=3.1.44, <5',
         'requests >=2.5.1, <3',


### PR DESCRIPTION
The older versions appear to quietly not support Python 3.12 :(. The latest versions do though and appear to work fine from some manual testing.

Fixes https://github.com/PeterJCLaw/srcomp-cli/issues/32