### PR TITLE
Warn when there are fewer teams than spaces in a schedule import

### DIFF
--- a/sr/comp/cli/import_schedule/__init__.py
+++ b/sr/comp/cli/import_schedule/__init__.py
@@ -4,8 +4,12 @@ Import a league.yaml from a schedule file.
 A schedule file specifies matches one-per-line, as follows:
 
 A 'match' consists of a number of unique identifiers separated by pipe
-characters. The total number of identifiers in the file should be equal
-to or greater than the number of teams in the compstate.
+characters. Identifiers are arbitrary strings, though a common pattern
+from schedule-generating tooling is to use integers.
+
+The total number of identifiers in the file should be equal to or greater
+than the number of teams in the compstate. In the latter case, `--ignore-ids`
+can optionally be used to indicate explicitly which to ignore.
 
 The number of identifiers in a given match must be a multiple of the
 number of teams per game (currently 4), up to the number of arenas in
@@ -110,12 +114,18 @@ def add_subparser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    # Changing this? Also update the reference to this argument in `build_schedule` in core.py
+    # Changing this? Also update the reference to this argument in
+    # `build_schedule` in core.py and in the docstring for this module.
     parser.add_argument(
         '-i',
         '--ignore-ids',
         type=loading.parse_ids,
-        help="Comma separated list of ids (as present in the schedule file) to ignore.",
+        help=(
+            "Comma separated list of ids (as present in the schedule file) to ignore. "
+            "Where this is not provided and the number of ids is greater than "
+            "the number of teams, heuristics will be used to determine which ids "
+            "are assigned teams."
+        ),
     )
     parser.add_argument(
         '--extend',

--- a/sr/comp/cli/import_schedule/__init__.py
+++ b/sr/comp/cli/import_schedule/__init__.py
@@ -110,6 +110,7 @@ def add_subparser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    # Changing this? Also update the reference to this argument in `build_schedule` in core.py
     parser.add_argument(
         '-i',
         '--ignore-ids',

--- a/sr/comp/cli/import_schedule/__init__.py
+++ b/sr/comp/cli/import_schedule/__init__.py
@@ -9,7 +9,9 @@ from schedule-generating tooling is to use integers.
 
 The total number of identifiers in the file should be equal to or greater
 than the number of teams in the compstate. In the latter case, `--ignore-ids`
-can optionally be used to indicate explicitly which to ignore.
+can optionally be used to indicate explicitly which to ignore. This can be
+useful when the number of teams does not evenly divide into the number of
+entrants in match.
 
 The number of identifiers in a given match must be a multiple of the
 number of teams per game (currently 4), up to the number of arenas in

--- a/sr/comp/cli/import_schedule/core.py
+++ b/sr/comp/cli/import_schedule/core.py
@@ -188,6 +188,19 @@ def build_schedule(
     if ids_to_ignore:
         ignore_ids(ids, ids_to_ignore)
 
+    # Quality/intent checks
+    if len(ids) > config.num_teams:
+        print(
+            f"Warning: more places than teams ({len(ids)} places, {config.num_teams} teams). "
+            "Heuristics will be used to attempt to minimise the number of empty "
+            "spaces in matches when mapping teams to places.",
+        )
+        if not ids_to_ignore:
+            print(
+                "Consider using `--ignore-ids` to indicate which ids should be "
+                "ignored if the default logic does not choose the right ones.",
+            )
+
     # Sanity checks
     if len(ids) < config.num_teams:
         raise ValueError(


### PR DESCRIPTION
While this *is* supported, the logic around this somewhat guesswork and it turns out to be non-obvious to users how to override the default if that logic does not produce the desired result.

Example output:
``` console
$ srcomp import-schedule . SR2025-t29-a7.txt --extend 
Warning: more places than teams (30 places, 29 teams). Heuristics will be used to attempt to minimise the number of empty spaces in matches when mapping teams to places.
Consider using `--ignore-ids` to indicate which ids should be ignored if the default logic does not choose the right ones.
```

Fixes https://github.com/PeterJCLaw/srcomp-cli/issues/34