### PR TITLE
Improve knocked-out-teams

### DIFF
--- a/sr/comp/cli/knocked_out_teams.py
+++ b/sr/comp/cli/knocked_out_teams.py
@@ -166,10 +166,10 @@ def teams_and_rounds(
         )
 
         teams_knocked_out = frozenset(
-            x.tla
-            for x in teams_by_last_appearance[i]
-            if x.tla not in teams_dropped_out
-            if x.all_matches_scored
+            team_info.tla
+            for team_info in teams_by_last_appearance[i]
+            if team_info.tla not in teams_dropped_out
+            if team_info.all_matches_scored
         )
 
         yield RoundResults(

--- a/sr/comp/cli/knocked_out_teams.py
+++ b/sr/comp/cli/knocked_out_teams.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 import argparse
+import collections
 import dataclasses
 import itertools
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import (
+    Callable,
+    Collection,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from pathlib import Path
 from typing import Protocol
 
@@ -11,7 +19,7 @@ from sr.comp.comp import SRComp
 from sr.comp.knockout_scheduler import UNKNOWABLE_TEAM
 from sr.comp.match_period import Match
 from sr.comp.teams import Team
-from sr.comp.types import MatchNumber, TLA
+from sr.comp.types import MatchId, MatchNumber, TLA
 
 
 class MinimalSchedule(Protocol):
@@ -25,26 +33,24 @@ class MinimalSchedule(Protocol):
 
 
 @dataclasses.dataclass(frozen=True)
-class Round:
+class RoundResults:
     number: int
     name: str
-    teams_this_round: frozenset[TLA]
 
-    teams_remaining: frozenset[TLA]
+    teams_dropped_out: frozenset[TLA]
     """
-    Teams known to be in this or future rounds.
+    Teams who dropped out during this round's matches.
 
-    This is needed to cope with knockout structures where some seeds bypass
-    early rounds.
+    This accounts for teams which dropped out of their own accord, rather than
+    because they were knocked out.
     """
 
-    teams_out: frozenset[TLA]
+    teams_knocked_out: frozenset[TLA]
     """
-    Teams knocked out by the prior round's matches.
+    Teams knocked out during this round's matches.
 
-    This will include teams whose matches in the prior round have not been
-    scored. Callers should check `prior_rounds_complete` to understand the state
-    of the scoring.
+    This includes only teams which are confirmed to be knocked out due to their
+    matches having all been scored.
     """
 
     prior_rounds_complete: bool
@@ -52,6 +58,14 @@ class Round:
     Whether the scoring for all the matches prior to ths round has completed and
     thus the knockouts for this round are completely known.
     """
+
+
+@dataclasses.dataclass(frozen=True)
+class TeamInfo:
+    tla: TLA
+    matches: Collection[Match]
+    last_appearance: int
+    all_matches_scored: bool
 
 
 def round_name(round_number: int, *, final_round_number: int) -> str:
@@ -65,59 +79,143 @@ def round_name(round_number: int, *, final_round_number: int) -> str:
     return f"Round {round_number}"
 
 
-def teams_and_rounds(teams: Mapping[TLA, Team], schedule: MinimalSchedule) -> Iterator[Round]:
+def teams_and_rounds(
+    teams: Mapping[TLA, Team],
+    schedule: MinimalSchedule,
+    has_scores: Callable[[Match], bool],
+) -> Iterator[RoundResults]:
+    """
+    Compute which teams were knockout out in which rounds.
+    """
+
+    # This must not rely too much on the structure of the actual knockout. In
+    # particular we cannot assume that winning teams will appear in every round
+    # -- since that constrains the nature of the knockout.
+    #
+    # Instead we rely on the following properties:
+    #  * Teams who have un-scored matches have not yet been knocked out
+    #  * Teams with fully scored matches and no future appearances must have
+    #    been knocked out
+    #  * Teams which have been knocked out can be considered as "knocked out" in
+    #    the round during which they had their last appearance
+    #
+    # Teams which drop out of their own accord are identified and excluded from
+    # consideration for being "knocked out".
+
+    def get_match_id(match: Match) -> MatchId:
+        return match.arena, match.num
+
     def teams_from_matches(matches: Iterable[Match]) -> frozenset[TLA]:
         teams = set(itertools.chain.from_iterable(x.teams for x in matches))
         return frozenset(x for x in teams if x is not None)
 
     rounds = schedule.knockout_rounds
+    knockout_matches = [m for r in rounds for m in r]
+
+    round_nums_by_match: dict[MatchId, int] = {}
+    for i, matches in enumerate(rounds):
+        for match in matches:
+            round_nums_by_match[get_match_id(match)] = i
+
+    matches_by_team: collections.defaultdict[TLA, list[Match]]
+    matches_by_team = collections.defaultdict(list)
+    for match in knockout_matches:
+        for tla in match.teams:
+            if tla is None or tla == UNKNOWABLE_TEAM:
+                continue
+            matches_by_team[tla].append(match)
+
+    team_infos: dict[TLA, TeamInfo] = {}
+    for tla, matches in matches_by_team.items():
+        team_infos[tla] = TeamInfo(
+            tla,
+            matches,
+            last_appearance=round_nums_by_match[get_match_id(matches[-1])],
+            all_matches_scored=all(has_scores(m) for m in matches),
+        )
+
+    teams_by_last_appearance: collections.defaultdict[int, list[TeamInfo]]
+    teams_by_last_appearance = collections.defaultdict(list)
+    for team_info in team_infos.values():
+        teams_by_last_appearance[team_info.last_appearance].append(team_info)
+
+    final_round_num = len(rounds) - 1
+
+    # Teams which don't enter the knockouts
 
     # Teams at the end of the league. Note that this doesn't include teams which
     # have dropped out of their own accord by that point.
     first_knockouts_match = MatchNumber(schedule.n_league_matches)
-    teams_last_round: frozenset[TLA]
-    teams_last_round = frozenset(
-        tla
-        for tla, team in teams.items()
-        if team.is_still_around(first_knockouts_match)
+    teams_after_league: collections.defaultdict[bool, list[TLA]]
+    teams_after_league = collections.defaultdict(list)
+    for tla, team in teams.items():
+        teams_after_league[team.is_still_around(first_knockouts_match)].append(tla)
+
+    yield RoundResults(
+        number=-1,
+        name="League",
+        teams_dropped_out=frozenset(teams_after_league[False]),
+        teams_knocked_out=frozenset(teams_after_league[True] - team_infos.keys()),
+        prior_rounds_complete=bool(team_infos),
     )
 
     final_round_num = len(rounds) - 1
+
+    # Results for the knockout rounds themselves
     for i, matches in enumerate(rounds):
         teams_this_round = teams_from_matches(matches)
-        teams_remaining = teams_from_matches(itertools.chain(*rounds[i:]))
 
-        teams_out = teams_last_round - teams_remaining
-
-        yield Round(
-            i,
-            round_name(i, final_round_number=final_round_num),
-            teams_this_round,
-            teams_remaining,
-            teams_out,
-            prior_rounds_complete=UNKNOWABLE_TEAM not in teams_this_round,
+        teams_dropped_out = frozenset(
+            tla
+            for tla, team in teams.items()
+            if team.is_still_around(matches[0].num)
+            if not team.is_still_around(matches[-1].num)
         )
 
-        teams_last_round = teams_this_round
+        teams_knocked_out = frozenset(
+            x.tla
+            for x in teams_by_last_appearance[i]
+            if x.tla not in teams_dropped_out
+            if x.all_matches_scored
+        )
+
+        yield RoundResults(
+            i,
+            round_name(i, final_round_number=final_round_num),
+            teams_dropped_out=teams_dropped_out,
+            teams_knocked_out=teams_knocked_out,
+            prior_rounds_complete=UNKNOWABLE_TEAM not in teams_this_round,
+        )
 
 
 def command(settings: argparse.Namespace) -> None:
     comp = SRComp(settings.compstate)
 
+    def has_scores(match: Match) -> bool:
+        return comp.scores.get_scores(match) is not None
+
     def print_teams(teams: Iterable[TLA]) -> None:
         for tla in sorted(teams):
             print(tla, comp.teams[tla].name)
 
-    for round_info in teams_and_rounds(comp.teams, comp.schedule):
-        print(f"## Teams not in {round_info.name}")
+    results = list(teams_and_rounds(comp.teams, comp.schedule, has_scores))
+
+    # Show all but the final (which has no real meaning).
+    # TODO: handle there being a tiebreaker.
+    for round_info in results[:-1]:
+        print(f"## Teams not longer present after {round_info.name}")
         print()
+        if round_info.teams_dropped_out:
+            print("-- Teams dropping out (of their own accord)")
+            print_teams(round_info.teams_dropped_out)
+            print()
 
         if not round_info.prior_rounds_complete:
             if settings.force:
                 print("Warning: ", end='')
 
             print(
-                "Prior rounds are not yet fully scored, knocked-out teams this "
+                "This round is not yet fully scored, knocked-out teams this "
                 "round are not yet confirmed.",
             )
             print()
@@ -125,7 +223,11 @@ def command(settings: argparse.Namespace) -> None:
             if not settings.force:
                 return
 
-        print_teams(round_info.teams_out)
+        if round_info.teams_dropped_out:
+            print("-- Teams knocked out")
+            print()
+
+        print_teams(round_info.teams_knocked_out)
 
         print()
 

--- a/sr/comp/cli/knocked_out_teams.py
+++ b/sr/comp/cli/knocked_out_teams.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import collections
 import dataclasses
-import itertools
 from collections.abc import (
     Callable,
     Collection,
@@ -53,10 +52,10 @@ class RoundResults:
     matches having all been scored.
     """
 
-    prior_rounds_complete: bool
+    is_complete: bool
     """
-    Whether the scoring for all the matches prior to ths round has completed and
-    thus the knockouts for this round are completely known.
+    Whether the scoring for all the matches in ths round has completed and thus
+    the knockouts for this round are completely known.
     """
 
 
@@ -105,10 +104,6 @@ def teams_and_rounds(
     def get_match_id(match: Match) -> MatchId:
         return match.arena, match.num
 
-    def teams_from_matches(matches: Iterable[Match]) -> frozenset[TLA]:
-        teams = set(itertools.chain.from_iterable(x.teams for x in matches))
-        return frozenset(x for x in teams if x is not None)
-
     rounds = schedule.knockout_rounds
     knockout_matches = [m for r in rounds for m in r]
 
@@ -156,15 +151,13 @@ def teams_and_rounds(
         name="League",
         teams_dropped_out=frozenset(teams_after_league[False]),
         teams_knocked_out=frozenset(teams_after_league[True] - team_infos.keys()),
-        prior_rounds_complete=bool(team_infos),
+        is_complete=bool(team_infos),
     )
 
     final_round_num = len(rounds) - 1
 
     # Results for the knockout rounds themselves
     for i, matches in enumerate(rounds):
-        teams_this_round = teams_from_matches(matches)
-
         teams_dropped_out = frozenset(
             tla
             for tla, team in teams.items()
@@ -184,7 +177,7 @@ def teams_and_rounds(
             round_name(i, final_round_number=final_round_num),
             teams_dropped_out=teams_dropped_out,
             teams_knocked_out=teams_knocked_out,
-            prior_rounds_complete=UNKNOWABLE_TEAM not in teams_this_round,
+            is_complete=all(has_scores(m) for m in matches),
         )
 
 
@@ -210,12 +203,12 @@ def command(settings: argparse.Namespace) -> None:
             print_teams(round_info.teams_dropped_out)
             print()
 
-        if not round_info.prior_rounds_complete:
+        if not round_info.is_complete:
             if settings.force:
                 print("Warning: ", end='')
 
             print(
-                "This round is not yet fully scored, knocked-out teams this "
+                "Scoring for this round is not yet complete, knocked-out teams this "
                 "round are not yet confirmed.",
             )
             print()

--- a/sr/comp/cli/knocked_out_teams.py
+++ b/sr/comp/cli/knocked_out_teams.py
@@ -3,13 +3,25 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import itertools
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
-from typing import Iterable, Iterator
+from typing import Protocol
 
 from sr.comp.comp import SRComp
 from sr.comp.knockout_scheduler import UNKNOWABLE_TEAM
 from sr.comp.match_period import Match
+from sr.comp.teams import Team
 from sr.comp.types import MatchNumber, TLA
+
+
+class MinimalSchedule(Protocol):
+    @property
+    def knockout_rounds(self) -> Sequence[Sequence[Match]]:
+        ...
+
+    @property
+    def n_league_matches(self) -> int:
+        ...
 
 
 @dataclasses.dataclass(frozen=True)
@@ -52,20 +64,20 @@ def round_name(rounds_left: int) -> str:
     return ""
 
 
-def teams_and_rounds(comp: SRComp) -> Iterator[Round]:
+def teams_and_rounds(teams: Mapping[TLA, Team], schedule: MinimalSchedule) -> Iterator[Round]:
     def teams_from_matches(matches: Iterable[Match]) -> frozenset[TLA]:
         teams = set(itertools.chain.from_iterable(x.teams for x in matches))
         return frozenset(x for x in teams if x is not None)
 
-    rounds = comp.schedule.knockout_rounds
+    rounds = schedule.knockout_rounds
 
     # Teams at the end of the league. Note that this doesn't include teams which
     # have dropped out of their own accord by that point.
-    first_knockouts_match = MatchNumber(comp.schedule.n_league_matches)
+    first_knockouts_match = MatchNumber(schedule.n_league_matches)
     teams_last_round: frozenset[TLA]
     teams_last_round = frozenset(
         tla
-        for tla, team in comp.teams.items()
+        for tla, team in teams.items()
         if team.is_still_around(first_knockouts_match)
     )
 
@@ -91,7 +103,7 @@ def teams_and_rounds(comp: SRComp) -> Iterator[Round]:
 def command(settings: argparse.Namespace) -> None:
     comp = SRComp(settings.compstate)
 
-    for round_info in teams_and_rounds(comp):
+    for round_info in teams_and_rounds(comp.teams, comp.schedule):
         print(f"## Teams not in round {round_info.number} ({round_info.name})")
         print()
 

--- a/sr/comp/cli/knocked_out_teams.py
+++ b/sr/comp/cli/knocked_out_teams.py
@@ -54,14 +54,15 @@ class Round:
     """
 
 
-def round_name(rounds_left: int) -> str:
+def round_name(round_number: int, *, final_round_number: int) -> str:
+    rounds_left = final_round_number - round_number
     if rounds_left == 0:
         return "Finals"
     elif rounds_left == 1:
         return "Semi Finals"
     elif rounds_left == 2:
         return "Quarter Finals"
-    return ""
+    return f"Round {round_number}"
 
 
 def teams_and_rounds(teams: Mapping[TLA, Team], schedule: MinimalSchedule) -> Iterator[Round]:
@@ -81,7 +82,7 @@ def teams_and_rounds(teams: Mapping[TLA, Team], schedule: MinimalSchedule) -> It
         if team.is_still_around(first_knockouts_match)
     )
 
-    last_round_num = len(rounds) - 1
+    final_round_num = len(rounds) - 1
     for i, matches in enumerate(rounds):
         teams_this_round = teams_from_matches(matches)
         teams_remaining = teams_from_matches(itertools.chain(*rounds[i:]))
@@ -90,7 +91,7 @@ def teams_and_rounds(teams: Mapping[TLA, Team], schedule: MinimalSchedule) -> It
 
         yield Round(
             i,
-            round_name(last_round_num - i),
+            round_name(i, final_round_number=final_round_num),
             teams_this_round,
             teams_remaining,
             teams_out,
@@ -103,8 +104,12 @@ def teams_and_rounds(teams: Mapping[TLA, Team], schedule: MinimalSchedule) -> It
 def command(settings: argparse.Namespace) -> None:
     comp = SRComp(settings.compstate)
 
+    def print_teams(teams: Iterable[TLA]) -> None:
+        for tla in sorted(teams):
+            print(tla, comp.teams[tla].name)
+
     for round_info in teams_and_rounds(comp.teams, comp.schedule):
-        print(f"## Teams not in round {round_info.number} ({round_info.name})")
+        print(f"## Teams not in {round_info.name}")
         print()
 
         if not round_info.prior_rounds_complete:
@@ -120,8 +125,7 @@ def command(settings: argparse.Namespace) -> None:
             if not settings.force:
                 return
 
-        for tla in sorted(round_info.teams_out):
-            print(tla, comp.teams[tla].name)
+        print_teams(round_info.teams_out)
 
         print()
 

--- a/tests/snapshots/knocked-out-teams.txt
+++ b/tests/snapshots/knocked-out-teams.txt
@@ -1,4 +1,4 @@
-## Teams not in Round 0
+## Teams not longer present after League
 
-Prior rounds are not yet fully scored, knocked-out teams this round are not yet confirmed.
+This round is not yet fully scored, knocked-out teams this round are not yet confirmed.
 

--- a/tests/snapshots/knocked-out-teams.txt
+++ b/tests/snapshots/knocked-out-teams.txt
@@ -1,4 +1,4 @@
-## Teams not in round 0 ()
+## Teams not in Round 0
 
 Prior rounds are not yet fully scored, knocked-out teams this round are not yet confirmed.
 

--- a/tests/snapshots/knocked-out-teams.txt
+++ b/tests/snapshots/knocked-out-teams.txt
@@ -1,4 +1,4 @@
 ## Teams not longer present after League
 
-This round is not yet fully scored, knocked-out teams this round are not yet confirmed.
+Scoring for this round is not yet complete, knocked-out teams this round are not yet confirmed.
 

--- a/tests/test_knocked_out_teams.py
+++ b/tests/test_knocked_out_teams.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import dataclasses
+import unittest
+from collections.abc import Collection, Mapping, Sequence
+
+from sr.comp.cli.knocked_out_teams import teams_and_rounds
+from sr.comp.knockout_scheduler import UNKNOWABLE_TEAM
+from sr.comp.match_period import Match
+from sr.comp.teams import Team
+from sr.comp.types import MatchNumber, TLA
+
+from .factories import build_match
+
+
+@dataclasses.dataclass(frozen=True)
+class FakeSchedule:
+    knockout_rounds: Sequence[Sequence[Match]]
+    n_league_matches: int
+
+
+class TestKnockedOutTeams(unittest.TestCase):
+    maxDiff = None
+
+    def get_team(self, tla: str, dropped_out_after: MatchNumber | None = None) -> Team:
+        return Team(TLA(tla), f"Team {tla}", rookie=False, dropped_out_after=dropped_out_after)
+
+    def get_teams(self, tlas: Collection[str]) -> Mapping[TLA, Team]:
+        return {TLA(x): self.get_team(x) for x in tlas}
+
+    def assertKnockedOutTeams(
+        self,
+        knockout_rounds: Sequence[Sequence[Match]],
+        expected_knockouts: list[frozenset[TLA]],
+    ) -> None:
+        result = list(teams_and_rounds(
+            self.teams,
+            FakeSchedule(
+                knockout_rounds=knockout_rounds,
+                n_league_matches=1,
+            ),
+        ))
+
+        self.assertEqual(
+            expected_knockouts,
+            [x.teams_out for x in result],
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.teams = self.get_teams([
+            'AAA',
+            'BBB',
+            'CCC',
+            'DDD',
+            'EEE',
+            'FFF',
+            'GGG',
+            'HHH',
+        ])
+        self.tlas = sorted(self.teams.keys())
+
+    def test_league_not_finished(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                ],
+                [
+                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(self.tlas),
+                frozenset(),
+            ],
+        )
+
+    def test_league_not_finished_with_dropout(self) -> None:
+        team = self.get_team('CCC', dropped_out_after=MatchNumber(0))
+        self.teams = {
+            **self.teams,
+            team.tla: team,
+        }
+
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                ],
+                [
+                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(self.tlas) - frozenset([team.tla]),
+                frozenset(),
+            ],
+        )
+
+    def test_league_just_finished(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    build_match(teams=self.tlas[:4]),
+                    build_match(teams=self.tlas[4:]),
+                ],
+                [
+                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(),
+                frozenset(self.tlas),
+            ],
+        )
+
+    def test_after_first_round(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    build_match(teams=self.tlas[:4]),
+                    build_match(teams=self.tlas[4:]),
+                ],
+                [
+                    build_match(teams=self.tlas[2:6]),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(),
+                frozenset(self.tlas[:2] + self.tlas[-2:]),
+            ],
+        )

--- a/tests/test_knocked_out_teams.py
+++ b/tests/test_knocked_out_teams.py
@@ -61,6 +61,10 @@ class TestKnockedOutTeams(unittest.TestCase):
         ])
         self.tlas = sorted(self.teams.keys())
 
+    # In these matches we assume that teams win in alphabetical order (which is
+    # also the order they're listed in `self.tlas`) -- so 'AAA' (index `0`) wins
+    # over 'CCC' (index `3`).
+
     def test_league_not_finished(self) -> None:
         self.assertKnockedOutTeams(
             knockout_rounds=[
@@ -126,11 +130,11 @@ class TestKnockedOutTeams(unittest.TestCase):
                     build_match(teams=self.tlas[4:]),
                 ],
                 [
-                    build_match(teams=self.tlas[2:6]),
+                    build_match(teams=self.tlas[:2] + self.tlas[4:6]),
                 ],
             ],
             expected_knockouts=[
                 frozenset(),
-                frozenset(self.tlas[:2] + self.tlas[-2:]),
+                frozenset(self.tlas[2:4] + self.tlas[-2:]),
             ],
         )

--- a/tests/test_knocked_out_teams.py
+++ b/tests/test_knocked_out_teams.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 import dataclasses
+import itertools
 import unittest
 from collections.abc import Collection, Mapping, Sequence
 
 from sr.comp.cli.knocked_out_teams import teams_and_rounds
 from sr.comp.knockout_scheduler import UNKNOWABLE_TEAM
-from sr.comp.match_period import Match
+from sr.comp.match_period import Match, MatchType
 from sr.comp.teams import Team
 from sr.comp.types import MatchNumber, TLA
 
-from .factories import build_match
+from . import factories
 
 
 @dataclasses.dataclass(frozen=True)
@@ -28,22 +29,46 @@ class TestKnockedOutTeams(unittest.TestCase):
     def get_teams(self, tlas: Collection[str]) -> Mapping[TLA, Team]:
         return {TLA(x): self.get_team(x) for x in tlas}
 
+    def build_match_info(
+        self,
+        *,
+        teams: Sequence[TLA | None],
+        is_scored: bool,
+        type_: MatchType = MatchType.knockout,
+    ) -> tuple[Match, bool]:
+        return (
+            factories.build_match(
+                num=next(self.match_counter),
+                teams=teams,
+                type_=MatchType.knockout,
+                use_resolved_ranking=True,
+            ),
+            is_scored,
+        )
+
     def assertKnockedOutTeams(
         self,
-        knockout_rounds: Sequence[Sequence[Match]],
+        knockout_rounds: Sequence[Sequence[tuple[Match, bool]]],
         expected_knockouts: list[frozenset[TLA]],
     ) -> None:
+        is_scored_map = {
+            (m.arena, m.num): is_scored
+            for r in knockout_rounds
+            for m, is_scored in r
+        }
+
         result = list(teams_and_rounds(
             self.teams,
             FakeSchedule(
-                knockout_rounds=knockout_rounds,
+                knockout_rounds=[[m for m, _ in r] for r in knockout_rounds],
                 n_league_matches=1,
             ),
+            has_scores=lambda m: is_scored_map[m.arena, m.num],
         ))
 
         self.assertEqual(
             expected_knockouts,
-            [x.teams_out for x in result],
+            [x.teams_knocked_out for x in result],
         )
 
     def setUp(self) -> None:
@@ -61,23 +86,29 @@ class TestKnockedOutTeams(unittest.TestCase):
         ])
         self.tlas = sorted(self.teams.keys())
 
+        self.n_league_matches = 2
+        self.match_counter = itertools.count(self.n_league_matches)
+
     # In these matches we assume that teams win in alphabetical order (which is
     # also the order they're listed in `self.tlas`) -- so 'AAA' (index `0`) wins
     # over 'CCC' (index `3`).
+
+    # Simple cases
 
     def test_league_not_finished(self) -> None:
         self.assertKnockedOutTeams(
             knockout_rounds=[
                 [
-                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
-                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
                 ],
                 [
-                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
                 ],
             ],
             expected_knockouts=[
                 frozenset(self.tlas),
+                frozenset(),
                 frozenset(),
             ],
         )
@@ -92,15 +123,16 @@ class TestKnockedOutTeams(unittest.TestCase):
         self.assertKnockedOutTeams(
             knockout_rounds=[
                 [
-                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
-                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
                 ],
                 [
-                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
                 ],
             ],
             expected_knockouts=[
                 frozenset(self.tlas) - frozenset([team.tla]),
+                frozenset(),
                 frozenset(),
             ],
         )
@@ -108,17 +140,66 @@ class TestKnockedOutTeams(unittest.TestCase):
     def test_league_just_finished(self) -> None:
         self.assertKnockedOutTeams(
             knockout_rounds=[
+                # -- we are here --
                 [
-                    build_match(teams=self.tlas[:4]),
-                    build_match(teams=self.tlas[4:]),
+                    self.build_match_info(teams=self.tlas[:4], is_scored=False),
+                    self.build_match_info(teams=self.tlas[4:], is_scored=False),
                 ],
                 [
-                    build_match(teams=[UNKNOWABLE_TEAM] * 4),
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
                 ],
             ],
             expected_knockouts=[
                 frozenset(),
-                frozenset(self.tlas),
+                frozenset(),
+                frozenset(),
+            ],
+        )
+
+    def test_league_just_finished_smaller_knockout_than_league(self) -> None:
+        team = self.get_team('ZZZ')
+        self.teams = {
+            **self.teams,
+            team.tla: team,
+        }
+
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                # -- we are here --
+                [
+                    self.build_match_info(teams=self.tlas[:4], is_scored=False),
+                    self.build_match_info(teams=self.tlas[4:], is_scored=False),
+                ],
+                [
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset([team.tla]),
+                frozenset(),
+                frozenset(),
+            ],
+        )
+
+    def test_during_first_round(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    self.build_match_info(teams=self.tlas[:4], is_scored=True),
+                    # -- we are here --
+                    self.build_match_info(teams=self.tlas[4:], is_scored=False),
+                ],
+                [
+                    self.build_match_info(
+                        teams=self.tlas[:2] + [UNKNOWABLE_TEAM] * 2,
+                        is_scored=False,
+                    ),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(),
+                frozenset(self.tlas[2:4]),
+                frozenset(),
             ],
         )
 
@@ -126,15 +207,354 @@ class TestKnockedOutTeams(unittest.TestCase):
         self.assertKnockedOutTeams(
             knockout_rounds=[
                 [
-                    build_match(teams=self.tlas[:4]),
-                    build_match(teams=self.tlas[4:]),
+                    self.build_match_info(teams=self.tlas[:4], is_scored=True),
+                    self.build_match_info(teams=self.tlas[4:], is_scored=True),
                 ],
+                # -- we are here --
                 [
-                    build_match(teams=self.tlas[:2] + self.tlas[4:6]),
+                    self.build_match_info(
+                        teams=self.tlas[:2] + self.tlas[4:6],
+                        is_scored=False,
+                    ),
                 ],
             ],
             expected_knockouts=[
                 frozenset(),
                 frozenset(self.tlas[2:4] + self.tlas[-2:]),
+                frozenset(),
+            ],
+        )
+
+    def test_after_final(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    self.build_match_info(teams=self.tlas[:4], is_scored=True),
+                    self.build_match_info(teams=self.tlas[4:], is_scored=True),
+                ],
+                [
+                    self.build_match_info(
+                        teams=self.tlas[:2] + self.tlas[4:6],
+                        is_scored=True,
+                    ),
+                ],
+                # -- we are here --
+            ],
+            expected_knockouts=[
+                frozenset(),
+                frozenset(self.tlas[2:4] + self.tlas[-2:]),
+                # everyone is knocked out in final (but it's not shown)
+                frozenset(self.tlas[:2] + self.tlas[4:6]),
+            ],
+        )
+
+    # Double elimination style cases
+
+    def test_double_elimination_before_first_round(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                # -- we are here --
+                [
+                    # 1. Initial round -- everyone
+                    self.build_match_info(teams=self.tlas[:4], is_scored=False),
+                    self.build_match_info(teams=self.tlas[4:], is_scored=False),
+                ],
+                [
+                    # 2. Lower bracket -- losers from round 1
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                ],
+                [
+                    # 3. Upper bracket -- winders from round 1
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                ],
+                [
+                    # 4. Lower bracket -- winners from round 2 + losers from round 3
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                ],
+                [
+                    # Final -- winners from round 3 + winners from round 4
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(),    # before first round
+                frozenset(),    # future
+                frozenset(),
+                frozenset(),
+                frozenset(),
+                frozenset(),
+            ],
+        )
+
+    def test_double_elimination_after_first_match(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    # 1. Initial round -- everyone
+                    self.build_match_info(teams=self.tlas[:4], is_scored=True),
+                    # -- we are here --
+                    self.build_match_info(teams=self.tlas[4:], is_scored=False),
+                ],
+                [
+                    # 2. Lower bracket -- losers from round 1
+                    self.build_match_info(
+                        teams=self.tlas[2:4] + [UNKNOWABLE_TEAM] * 2,
+                        is_scored=False,
+                    ),
+                ],
+                [
+                    # 3. Upper bracket -- winders from round 1
+                    self.build_match_info(
+                        teams=self.tlas[:2] + [UNKNOWABLE_TEAM] * 2,
+                        is_scored=False,
+                    ),
+                ],
+                [
+                    # 4. Lower bracket -- winners from round 2 + losers from round 3
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                ],
+                [
+                    # Final -- winners from round 3 + winners from round 4
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(),    # before first round
+                frozenset(),    # partial future
+                frozenset(),
+                frozenset(),
+                frozenset(),
+                frozenset(),
+            ],
+        )
+
+    def test_double_elimination_after_first_round(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    # 1. Initial round -- everyone
+                    self.build_match_info(teams=self.tlas[:4], is_scored=True),
+                    self.build_match_info(teams=self.tlas[4:], is_scored=True),
+                ],
+                # -- we are here --
+                [
+                    # 2. Lower bracket -- losers from round 1
+                    self.build_match_info(
+                        teams=self.tlas[2:4] + self.tlas[6:],
+                        is_scored=False,
+                    ),
+                ],
+                [
+                    # 3. Upper bracket -- winders from round 1
+                    self.build_match_info(
+                        teams=self.tlas[:2] + self.tlas[4:6],
+                        is_scored=False,
+                    ),
+                ],
+                [
+                    # 4. Lower bracket -- winners from round 2 + losers from round 3
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                ],
+                [
+                    # Final -- winners from round 3 + winners from round 4
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(),    # before first round
+                frozenset(),    # knocked out in round 1
+                frozenset(),    # future
+                frozenset(),
+                frozenset(),
+                frozenset(),
+            ],
+        )
+
+    def test_double_elimination_after_second_round(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    # 1. Initial round -- everyone
+                    self.build_match_info(teams=self.tlas[:4], is_scored=True),
+                    self.build_match_info(teams=self.tlas[4:], is_scored=True),
+                ],
+                [
+                    # 2. Lower bracket -- losers from round 1
+                    self.build_match_info(
+                        teams=self.tlas[2:4] + self.tlas[6:],
+                        is_scored=True,
+                    ),
+                ],
+                # -- we are here --
+                [
+                    # 3. Upper bracket -- winders from round 1
+                    self.build_match_info(
+                        teams=self.tlas[:2] + self.tlas[4:6],
+                        is_scored=False,
+                    ),
+                ],
+                [
+                    # 4. Lower bracket -- winners from round 2 + losers from round 3
+                    self.build_match_info(
+                        teams=self.tlas[2:4] + [UNKNOWABLE_TEAM] * 2,
+                        is_scored=False,
+                    ),
+                ],
+                [
+                    # Final -- winners from round 3 + winners from round 4
+                    self.build_match_info(teams=[UNKNOWABLE_TEAM] * 4, is_scored=False),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(),    # before first round
+                frozenset(),    # knocked out in round 1
+                frozenset(self.tlas[6:]),   # knocked out in round 2
+                frozenset(),    # future
+                frozenset(),
+                frozenset(),
+            ],
+        )
+
+    def test_double_elimination_after_third_round(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    # 1. Initial round -- everyone
+                    self.build_match_info(teams=self.tlas[:4], is_scored=True),
+                    self.build_match_info(teams=self.tlas[4:], is_scored=True),
+                ],
+                [
+                    # 2. Lower bracket -- losers from round 1
+                    self.build_match_info(
+                        teams=self.tlas[2:4] + self.tlas[6:],
+                        is_scored=True,
+                    ),
+                ],
+                [
+                    # 3. Upper bracket -- winders from round 1
+                    self.build_match_info(
+                        teams=self.tlas[:2] + self.tlas[4:6],
+                        is_scored=True,
+                    ),
+                ],
+                # -- we are here --
+                [
+                    # 4. Lower bracket -- winners from round 2 + losers from round 3
+                    self.build_match_info(
+                        teams=self.tlas[2:4] + self.tlas[4:6],
+                        is_scored=False,
+                    ),
+                ],
+                [
+                    # Final -- winners from round 3 + winners from round 4
+                    self.build_match_info(
+                        teams=self.tlas[:2] + [UNKNOWABLE_TEAM] * 2,
+                        is_scored=False,
+                    ),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(),    # before first round
+                frozenset(),    # knocked out in round 1
+                frozenset(self.tlas[6:]),   # knocked out in round 2
+                frozenset(),    # knocked out in round 3
+                frozenset(),    # future
+                frozenset(),
+            ],
+        )
+
+    def test_double_elimination_after_fourth_round(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    # 1. Initial round -- everyone
+                    self.build_match_info(teams=self.tlas[:4], is_scored=True),
+                    self.build_match_info(teams=self.tlas[4:], is_scored=True),
+                ],
+                [
+                    # 2. Lower bracket -- losers from round 1
+                    self.build_match_info(
+                        teams=self.tlas[2:4] + self.tlas[6:],
+                        is_scored=True,
+                    ),
+                ],
+                [
+                    # 3. Upper bracket -- winders from round 1
+                    self.build_match_info(
+                        teams=self.tlas[:2] + self.tlas[4:6],
+                        is_scored=True,
+                    ),
+                ],
+                [
+                    # 4. Lower bracket -- winners from round 2 + losers from round 3
+                    self.build_match_info(
+                        teams=self.tlas[2:4] + self.tlas[4:6],
+                        is_scored=True,
+                    ),
+                ],
+                # -- we are here --
+                [
+                    # Final -- winners from round 3 + winners from round 4
+                    self.build_match_info(
+                        teams=self.tlas[:2] + self.tlas[2:4] * 2,
+                        is_scored=False,
+                    ),
+                ],
+            ],
+            expected_knockouts=[
+                frozenset(),    # before first round
+                frozenset(),    # knocked out in round 1
+                frozenset(self.tlas[6:]),   # knocked out in round 2
+                frozenset(),    # knocked out in round 3
+                frozenset(self.tlas[4:6]),  # knocked out in round 4
+                frozenset(),    # future
+            ],
+        )
+
+    def test_double_elimination_after_final(self) -> None:
+        self.assertKnockedOutTeams(
+            knockout_rounds=[
+                [
+                    # 1. Initial round -- everyone
+                    self.build_match_info(teams=self.tlas[:4], is_scored=True),
+                    self.build_match_info(teams=self.tlas[4:], is_scored=True),
+                ],
+                [
+                    # 2. Lower bracket -- losers from round 1
+                    self.build_match_info(
+                        teams=self.tlas[2:4] + self.tlas[6:],
+                        is_scored=True,
+                    ),
+                ],
+                [
+                    # 3. Upper bracket -- winders from round 1
+                    self.build_match_info(
+                        teams=self.tlas[:2] + self.tlas[4:6],
+                        is_scored=True,
+                    ),
+                ],
+                [
+                    # 4. Lower bracket -- winners from round 2 + losers from round 3
+                    self.build_match_info(
+                        teams=self.tlas[2:4] + self.tlas[4:6],
+                        is_scored=True,
+                    ),
+                ],
+                [
+                    # Final -- winners from round 3 + winners from round 4
+                    self.build_match_info(
+                        teams=self.tlas[:2] + self.tlas[2:4],
+                        is_scored=True,
+                    ),
+                ],
+                # -- we are here --
+            ],
+            expected_knockouts=[
+                frozenset(),    # before first round
+                frozenset(),    # knocked out in round 1
+                frozenset(self.tlas[6:]),   # knocked out in round 2
+                frozenset(),    # knocked out in round 3
+                frozenset(self.tlas[4:6]),  # knocked out in round 4
+                frozenset(self.tlas[:4]),   # everyone is knocked out in final (not shown)
             ],
         )


### PR DESCRIPTION
### Summary

This introduces tests for the knocked-out-teams command, makes some small rendering tweaks and then rewrites it to handle knockout structures which are not single-elimination.

This takes a different approach than the implementation actually used for SR2025, though hopefully one which is better/easier to reason about.

Review by commit may be useful for the early commits.
For the later change suggest reviewing the new state of the tests & code as fresh code rather than as a diff.

### Validation

I've validated this by comparing its output to that of the [implementation used for SR2025](https://github.com/PeterJCLaw/srcomp-cli/commit/6bf2407defeea8a826a382f915d10e3e8940f8fc), it produces the same sets of eliminations for all states during the knockouts. (Note that that prior implementation had an off by one mismatch between the displayed headers and what was actually shown)

I've also compared this to the implementation on `main` for all commits during the knockouts during SR2024 (i.e: single elimination), where it also produces comparable results. (The implementation on `main` makes eager assumptions about teams being knocked out when matches are unscored, which this algorithm doesn't)

