### PR TITLE
Command to enable modernising the static knockout scheduler config

### DIFF
--- a/docs/commands/modernise-static-knockout.rst
+++ b/docs/commands/modernise-static-knockout.rst
@@ -1,0 +1,8 @@
+modernise-static-knockout
+=========================
+
+.. argparse::
+   :module: sr.comp.cli.command_line
+   :func: argument_parser
+   :prog: srcomp
+   :path: modernise-static-knockout

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'python-dateutil >=2.2, <3',
         'Fabric >= 2.7, <4',
         'invoke >= 1.7, <3',
-        'sr.comp >=1.8, <2',
+        'sr.comp >=1.13, <2',
         'reportlab >=3.1.44, <5',
         'requests >=2.5.1, <3',
         # Work around https://sourceforge.net/p/ruamel-yaml/tickets/534/, where

--- a/sr/comp/cli/command_line.py
+++ b/sr/comp/cli/command_line.py
@@ -16,6 +16,7 @@ from . import (
     knocked_out_teams,
     list_midi_ports,
     match_order_teams,
+    modernise_static_knockout,
     print_schedule,
     schedule_league,
     scorer,
@@ -59,6 +60,7 @@ def argument_parser() -> argparse.ArgumentParser:
     knocked_out_teams.add_subparser(subparsers)
     list_midi_ports.add_subparser(subparsers)
     match_order_teams.add_subparser(subparsers)
+    modernise_static_knockout.add_subparser(subparsers)
     print_schedule.add_subparser(subparsers)
     schedule_league.add_subparser(subparsers)
     scorer.add_subparser(subparsers)

--- a/sr/comp/cli/modernise_static_knockout.py
+++ b/sr/comp/cli/modernise_static_knockout.py
@@ -20,6 +20,11 @@ def command(settings: argparse.Namespace) -> None:
 
         # Update in-place to preserve comments as much as we can
         new_config = StaticScheduler.modernise_config_if_needed(static_knockout)
+
+        if new_config == static_knockout:
+            print("Static knockout config already up to date, nothing to do")
+            return
+
         static_knockout.clear()
         static_knockout.update(new_config)
 

--- a/sr/comp/cli/modernise_static_knockout.py
+++ b/sr/comp/cli/modernise_static_knockout.py
@@ -1,0 +1,38 @@
+"""
+Update the static knockout schedule configuration format.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def command(settings: argparse.Namespace) -> None:
+    from sr.comp.cli import yaml_round_trip as yaml
+    from sr.comp.knockout_scheduler import StaticScheduler
+
+    with yaml.edit(settings.compstate / 'schedule.yaml') as schedule:
+        static_knockout = schedule.get('static_knockout')
+        if static_knockout is None:
+            print("Warning: Schedule does not have a static configuration")
+            return
+
+        # Update in-place to preserve comments as much as we can
+        new_config = StaticScheduler.modernise_config_if_needed(static_knockout)
+        static_knockout.clear()
+        static_knockout.update(new_config)
+
+
+def add_subparser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    parser = subparsers.add_parser(
+        'modernise-static-knockout',
+        help=__doc__.strip().splitlines()[0],
+        description=__doc__,
+    )
+    parser.add_argument(
+        'compstate',
+        help="competition state repository",
+        type=Path,
+    )
+    parser.set_defaults(func=command)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import datetime
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
 from typing import Sequence
 
 from dateutil.tz import UTC
@@ -31,3 +36,22 @@ def build_match(
         type_,
         use_resolved_ranking,
     )
+
+
+@contextlib.contextmanager
+def dummy_compstate(revision: str | None = None) -> Iterator[Path]:
+    REF_COMPSTATE = Path(__file__).parent / 'dummy'
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        def _git(*args: str | Path) -> None:
+            subprocess.check_call(
+                ['git', *args],
+                env={'GIT_ADVICE': "0"},
+                cwd=tempdir,
+            )
+
+        _git('clone', '--quiet', REF_COMPSTATE, tempdir)
+        if revision is not None:
+            _git('checkout', '--quiet', revision)
+
+        yield Path(tempdir)

--- a/tests/test_modernise_static_knockout.py
+++ b/tests/test_modernise_static_knockout.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import unittest
+
+from sr.comp.cli.modernise_static_knockout import command
+
+from .factories import dummy_compstate
+
+
+class ModerniseStaticKnockoutTests(unittest.TestCase):
+    maxDiff = None
+
+    def test_already_modernised(self) -> None:
+        with dummy_compstate(
+            revision='b03776b785125c7e6fa15ed32f309fbaab0279ff',
+        ) as compstate_path:
+            original = (compstate_path / 'schedule.yaml').read_text()
+
+            command(argparse.Namespace(compstate=compstate_path))
+
+            new = (compstate_path / 'schedule.yaml').read_text()
+
+            self.assertEqual(original, new, "Should not have modified already valid file")
+
+    def test_modernise(self) -> None:
+        with dummy_compstate(
+            revision='76d8378253e71a1366b4c42b16c16df2f71fff2c',
+        ) as compstate_path:
+            expected = (compstate_path / 'schedule.yaml').read_text()
+
+        with dummy_compstate(
+            revision='1d346d9a6ce12bb5eae34f08e7296fa335f1cfd4',
+        ) as compstate_path:
+            command(argparse.Namespace(compstate=compstate_path))
+
+            new = (compstate_path / 'schedule.yaml').read_text()
+
+            self.assertEqual(
+                expected,
+                new,
+                "Should not have modified already valid file",
+            )


### PR DESCRIPTION
This is done automatically on load internally, this command allows for saving the updated version back to the compstate.

~Blocked on a new upstream release containing at least https://github.com/PeterJCLaw/srcomp/commit/5eca5ec3f31b44927e5ae3761f2de921b127d9f9.~