### PR TITLE
Extract user interactions

### DIFF
--- a/sr/comp/cli/delay.py
+++ b/sr/comp/cli/delay.py
@@ -4,36 +4,38 @@ import argparse
 from pathlib import Path
 
 from sr.comp.cli import add_delay, deploy
+from sr.comp.cli.interaction_utils import CLIInteractions
 
 
 def command(args: argparse.Namespace) -> None:
     from sr.comp.raw_compstate import RawCompstate
 
     compstate = RawCompstate(args.compstate, local_only=False)
-    hosts = deploy.get_deployments(compstate)
+    interactions = CLIInteractions()
+    hosts = deploy.get_deployments(compstate, interactions)
 
-    deploy.require_no_changes(compstate)
+    deploy.require_no_changes(compstate, interactions)
 
     if not args.no_pull:
-        with deploy.exit_on_exception():
+        with interactions.make_fatal():
             compstate.pull_fast_forward()
 
     how_long, when = add_delay.command(args)
 
     if args.when != 'now':
         msg = f"Confirm adding {how_long} delay at {when}"
-        if not deploy.query_bool(msg, default_val=True):
+        if not interactions.query_bool(msg, default=True):
             print("Leaving state with local modifications")
             exit()
 
-    deploy.require_valid(compstate)
+    deploy.require_valid(compstate, interactions)
 
-    with deploy.exit_on_exception(kind=RuntimeError):
+    with interactions.make_fatal(kind=RuntimeError):
         compstate.stage('schedule.yaml')
         msg = f"Adding {args.how_long} delay at {when}"
         compstate.commit(msg)
 
-    deploy.run_deployments(args, compstate, hosts)
+    deploy.run_deployments(args, compstate, hosts, interactions)
 
 
 def add_subparser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:

--- a/sr/comp/cli/deploy.py
+++ b/sr/comp/cli/deploy.py
@@ -25,43 +25,32 @@ from __future__ import annotations
 import argparse
 import io
 import sys
-import textwrap
 import warnings
 from contextlib import contextmanager
-from typing import (
-    Any,
-    cast,
-    Iterable,
-    Iterator,
-    Sequence,
-    TextIO,
-    TYPE_CHECKING,
-)
+from typing import cast, Iterable, Iterator, TextIO, TYPE_CHECKING, TypeVar
+
+from .deploy_api import CLIInteractions, UserInteractions
 
 if TYPE_CHECKING:
     from sr.comp.raw_compstate import RawCompstate
 
+T = TypeVar('T')
+
 API_TIMEOUT_SECONDS = 3
 DEPLOY_USER = 'srcomp'
-BOLD = '\033[1m'
-FAIL = '\033[91m'
-OKBLUE = '\033[94m'
-ENDC = '\033[0m'
-
-
-def format_fail(message: str) -> str:
-    return BOLD + FAIL + message + ENDC
 
 
 @contextmanager
 def exit_on_exception(
+    interactions: UserInteractions[T],
     msg: str = '{0}',
     kind: type[Exception] = Exception,
 ) -> Iterator[None]:
     try:
         yield
     except kind as e:
-        print_fail(msg.format(e))
+        interactions.show_error(msg.format(e))
+        # TODO(PR): interactions exit?
         exit(1)
 
 
@@ -104,60 +93,9 @@ def guard_unicode_output(stream: TextIO) -> Iterator[None]:
         stream.write = orig_write  # type: ignore[method-assign]
 
 
-def print_fail(message: str, **kargs: Any) -> None:
-    print(format_fail(message), **kargs)
-
-
-def print_buffer(buf: io.StringIO) -> None:
-    content = buf.getvalue().rstrip()
-    if content:
-        print(textwrap.indent(content, '> '))
-
-
-def get_input(prompt: str) -> str:
-    # Wrapper to simplify mocking
-    return input(prompt)
-
-
-def query(
-    question: str,
-    options: Sequence[str],
-    default: str | None = None,
-) -> str:
-    if default:
-        assert default in options
-
-    options = [o.upper() if o == default else o.lower() for o in options]
-    assert len(set(options)) == len(options)
-    opts = '/'.join(options)
-
-    query = format_fail(f"{question.rstrip()} [{opts}]: ")
-
-    while True:
-        # Loop until we get a suitable response from the user
-        resp = get_input(query).lower()
-
-        if resp in options:
-            return resp
-
-        # If there's a default value, use that
-        if default:
-            return default
-
-
-def query_bool(question: str, default_val: bool | None = None) -> bool:
-    options = ('y', 'n')
-    if default_val is True:
-        default: str | None = 'y'
-    elif default_val is False:
-        default = 'n'
-    else:
-        default = None
-    return query(question, options, default) == 'y'
-
-
-def query_warn(msg: object) -> None:
-    if not query_bool(f"Warning: {msg}. Continue?", False):
+def query_warn(msg: object, interactions: UserInteractions[T]) -> None:
+    if not interactions.query_bool(f"Warning: {msg}. Continue?", False):
+        # TODO(PR): interactions exit?
         exit(1)
 
 
@@ -165,8 +103,14 @@ def ref_compstate(host: str) -> str:
     return f'ssh://{DEPLOY_USER}@{host}/~/compstate.git'
 
 
-def deploy_to(compstate: RawCompstate, host: str, revision: str, verbose: bool) -> int:
-    print(BOLD + f"Deploying to {host}:" + ENDC)
+def deploy_to(
+    compstate: RawCompstate,
+    host: str,
+    revision: str,
+    verbose: bool,
+    interactions: UserInteractions[T],
+) -> int:
+    interactions.show_strong(f"Deploying to {host}:")
 
     from fabric import Connection  # type: ignore[import-untyped]
     from invoke.exceptions import UnexpectedExit
@@ -183,7 +127,7 @@ def deploy_to(compstate: RawCompstate, host: str, revision: str, verbose: bool) 
         # revision exists in the target, since this push will simply no-op
         # if it's already present
         revspec = '{0}:refs/heads/deploy-{0}'.format(revision)
-        with exit_on_exception(kind=RuntimeError):
+        with exit_on_exception(interactions, kind=RuntimeError):
             compstate.push(
                 url,
                 revspec,
@@ -200,19 +144,19 @@ def deploy_to(compstate: RawCompstate, host: str, revision: str, verbose: bool) 
         retcode: int = result.exited
 
         if verbose or retcode != 0:
-            print_buffer(stdout)
+            interactions.show_buffer(stdout)
 
-        print_buffer(stderr)
+        interactions.show_buffer(stderr)
 
         return retcode
 
 
-def get_deployments(compstate: RawCompstate) -> list[str]:
-    with exit_on_exception("Failed to get deployments from state ({0})."):
+def get_deployments(compstate: RawCompstate, interactions: UserInteractions[T]) -> list[str]:
+    with exit_on_exception(interactions, "Failed to get deployments from state ({0})."):
         return compstate.deployments
 
 
-def get_current_state(host: str) -> str | None:
+def get_current_state(host: str, interactions: UserInteractions[T]) -> str | None:
     import requests
 
     url = f'http://{host}/comp-api/state'
@@ -221,7 +165,8 @@ def get_current_state(host: str) -> str | None:
         response.raise_for_status()
         raw_state = response.json()
     except Exception as e:
-        print(e)
+        # TODO(PR): Should this just raise and be handled in the level above?
+        interactions.show_info(str(e))
         return None
     else:
         # While this could be any JSON, the schema is that this is a string
@@ -229,7 +174,13 @@ def get_current_state(host: str) -> str | None:
         return cast(str, raw_state['state'])
 
 
-def check_host_state(compstate: RawCompstate, host: str, revision: str, verbose: bool) -> bool:
+def check_host_state(
+    compstate: RawCompstate,
+    host: str,
+    revision: str,
+    verbose: bool,
+    interactions: UserInteractions[T],
+) -> bool:
     """
     Compares the host state to the revision we want to deploy. If the
     host's state isn't in the history of the deploy revision then various
@@ -240,10 +191,10 @@ def check_host_state(compstate: RawCompstate, host: str, revision: str, verbose:
     SKIP = True
     UPDATE = False
     if verbose:
-        print(f"Checking host state for {host} (timeout {API_TIMEOUT_SECONDS} seconds).")
-    state = get_current_state(host)
+        interactions.show_info(f"Checking host state for {host} (timeout {API_TIMEOUT_SECONDS} seconds).")
+    state = get_current_state(host, interactions)
     if not state:
-        if query_bool(
+        if interactions.query_bool(
             f"Failed to get state for {host}, cannot advise about history. Deploy anyway?",
             True,
         ):
@@ -252,7 +203,7 @@ def check_host_state(compstate: RawCompstate, host: str, revision: str, verbose:
             return SKIP
 
     if state == revision:
-        print(f"Host {host} already has requested revision ({revision[:8]})")
+        interactions.show_info(f"Host {host} already has requested revision ({revision[:8]})")
         return SKIP
 
     # Ideal case:
@@ -261,85 +212,92 @@ def check_host_state(compstate: RawCompstate, host: str, revision: str, verbose:
 
     # Check for unknown commit
     if not compstate.has_commit(state):
-        if query_bool(f"Host {host} has unknown state '{state}'. Try to fetch it?", True):
+        if interactions.query_bool(f"Host {host} has unknown state '{state}'. Try to fetch it?", True):
             compstate.fetch('origin', quiet=True)
             compstate.fetch(ref_compstate(host), ('HEAD', state), quiet=True)
 
     # Old revision:
     if compstate.has_descendant(state):
-        if query_bool(f"Host {host} has more recent state '{state}'. Deploy anyway?", True):
+        if interactions.query_bool(f"Host {host} has more recent state '{state}'. Deploy anyway?", True):
             return UPDATE
         else:
             return SKIP
 
     # Some other revision:
     if compstate.has_commit(state):
-        if query_bool(f"Host {host} has sibling state '{state}'. Deploy anyway?", True):
+        if interactions.query_bool(f"Host {host} has sibling state '{state}'. Deploy anyway?", True):
             return UPDATE
         else:
             return SKIP
 
     # An unknown state
-    if query_bool(f"Host {host} has unknown state '{state}'. Deploy anyway?", True):
+    if interactions.query_bool(f"Host {host} has unknown state '{state}'. Deploy anyway?", True):
         return UPDATE
     else:
         return SKIP
 
 
-def require_no_changes(compstate: RawCompstate) -> None:
+def require_no_changes(compstate: RawCompstate, interactions: UserInteractions[T]) -> None:
     if compstate.has_changes:
-        print_fail(
+        interactions.show_error(
             "Cannot deploy state with local changes. "
             "Commit or remove them and re-run.",
         )
-        compstate.show_changes()
+        interactions.show_info(
+            compstate.git(['status'], return_output=True),
+        )
+        # TODO(PR): interactions exit?
         exit(1)
 
 
-def require_valid(compstate: RawCompstate) -> None:
+def require_valid(compstate: RawCompstate, interactions: UserInteractions[T]) -> None:
     from sr.comp.validation import validate
 
-    with exit_on_exception("State cannot be loaded: {0}"):
+    with exit_on_exception(interactions, "State cannot be loaded: {0}"):
         comp = compstate.load()
 
     num_errors = validate(comp)
     if num_errors:
-        query_warn("State has validation errors (see above)")
+        query_warn("State has validation errors (see above)", interactions)
 
 
 def run_deployments(
     args: argparse.Namespace,
     compstate: RawCompstate,
     hosts: Iterable[str],
+    interactions: UserInteractions[T],
 ) -> None:
     revision = compstate.rev_parse('HEAD')
     for host in hosts:
         if not args.skip_host_check:
-            skip_host = check_host_state(compstate, host, revision, args.verbose)
+            skip_host = check_host_state(compstate, host, revision, args.verbose, interactions)
             if skip_host:
-                print(BOLD + f"Skipping {host}." + ENDC)
+                interactions.show_strong(f"Skipping {host}.")
                 continue
 
-        retcode = deploy_to(compstate, host, revision, args.verbose)
+        retcode = deploy_to(compstate, host, revision, args.verbose, interactions)
         if retcode != 0:
             # TODO: work out if it makes sense to try to rollback here?
-            print_fail(f"Failed to deploy to '{host}' (exit status: {retcode}).")
+            interactions.show_error(f"Failed to deploy to '{host}' (exit status: {retcode}).")
+            # TODO(PR): interactions exit?
             exit(retcode)
 
-    print(BOLD + OKBLUE + "Done" + ENDC)
+    interactions.show_strong_ok("Done")
 
 
 def command(args: argparse.Namespace) -> None:
     from sr.comp.raw_compstate import RawCompstate
 
+    interactions = CLIInteractions()
+
     with guard_unicode_output(sys.stdout), guard_unicode_output(sys.stderr):
         compstate = RawCompstate(args.compstate, local_only=False)
-        hosts = get_deployments(compstate)
+        hosts = get_deployments(compstate, interactions)
 
-        require_no_changes(compstate)
-        require_valid(compstate)
+        require_no_changes(compstate, interactions)
+        require_valid(compstate, interactions)
 
-        run_deployments(args, compstate, hosts)
+        run_deployments(args, compstate, hosts, interactions)
 
 
 def add_options(parser: argparse.ArgumentParser) -> None:

--- a/sr/comp/cli/deploy.py
+++ b/sr/comp/cli/deploy.py
@@ -180,7 +180,9 @@ def check_host_state(
     SKIP = True
     UPDATE = False
     if verbose:
-        interactions.show_info(f"Checking host state for {host} (timeout {API_TIMEOUT_SECONDS} seconds).")
+        interactions.show_info(
+            f"Checking host state for {host} (timeout {API_TIMEOUT_SECONDS} seconds).",
+        )
     state = get_current_state(host, interactions)
     if not state:
         if interactions.query_bool(
@@ -201,26 +203,38 @@ def check_host_state(
 
     # Check for unknown commit
     if not compstate.has_commit(state):
-        if interactions.query_bool(f"Host {host} has unknown state '{state}'. Try to fetch it?", True):
+        if interactions.query_bool(
+            f"Host {host} has unknown state '{state}'. Try to fetch it?",
+            default=True,
+        ):
             compstate.fetch('origin', quiet=True)
             compstate.fetch(ref_compstate(host), ('HEAD', state), quiet=True)
 
     # Old revision:
     if compstate.has_descendant(state):
-        if interactions.query_bool(f"Host {host} has more recent state '{state}'. Deploy anyway?", True):
+        if interactions.query_bool(
+            f"Host {host} has more recent state '{state}'. Deploy anyway?",
+            default=True,
+        ):
             return UPDATE
         else:
             return SKIP
 
     # Some other revision:
     if compstate.has_commit(state):
-        if interactions.query_bool(f"Host {host} has sibling state '{state}'. Deploy anyway?", True):
+        if interactions.query_bool(
+            f"Host {host} has sibling state '{state}'. Deploy anyway?",
+            default=True,
+        ):
             return UPDATE
         else:
             return SKIP
 
     # An unknown state
-    if interactions.query_bool(f"Host {host} has unknown state '{state}'. Deploy anyway?", True):
+    if interactions.query_bool(
+        f"Host {host} has unknown state '{state}'. Deploy anyway?",
+        default=True,
+    ):
         return UPDATE
     else:
         return SKIP

--- a/sr/comp/cli/deploy.py
+++ b/sr/comp/cli/deploy.py
@@ -44,6 +44,10 @@ API_TIMEOUT_SECONDS = 3
 DEPLOY_USER = 'srcomp'
 
 
+class UnableToGetStateError(RuntimeError):
+    pass
+
+
 @contextmanager
 def guard_unicode_output(stream: TextIO) -> Iterator[None]:
     """
@@ -145,22 +149,32 @@ def get_deployments(compstate: RawCompstate, interactions: UserInteractions[T]) 
         return compstate.deployments
 
 
-def get_current_state(host: str, interactions: UserInteractions[T]) -> str | None:
+def get_current_state(host: str, interactions: UserInteractions[T]) -> str:
+    """
+    Determine the currently-deployed state on the given host via its HTTP API.
+
+    In the case of errors, a suitable error will be emitted via the given
+    ``interactions`` and ``UnableToGetStateError`` will be raised.
+    """
     import requests
 
     url = f'http://{host}/comp-api/state'
+
     try:
         response = requests.get(url, timeout=API_TIMEOUT_SECONDS)
         response.raise_for_status()
         raw_state = response.json()
-    except Exception as e:
-        # TODO(PR): Should this just raise and be handled in the level above?
+    except requests.RequestException as e:
         interactions.show_info(str(e))
-        return None
-    else:
+        raise UnableToGetStateError from e
+
+    try:
         # While this could be any JSON, the schema is that this is a string
         # containing the commit hash of the compstate.
         return cast(str, raw_state['state'])
+    except KeyError as e:
+        interactions.show_info(str(e))
+        raise UnableToGetStateError from e
 
 
 def check_host_state(
@@ -183,8 +197,10 @@ def check_host_state(
         interactions.show_info(
             f"Checking host state for {host} (timeout {API_TIMEOUT_SECONDS} seconds).",
         )
-    state = get_current_state(host, interactions)
-    if not state:
+
+    try:
+        state = get_current_state(host, interactions)
+    except UnableToGetStateError:
         if interactions.query_bool(
             f"Failed to get state for {host}, cannot advise about history. Deploy anyway?",
             True,

--- a/sr/comp/cli/deploy.py
+++ b/sr/comp/cli/deploy.py
@@ -29,7 +29,11 @@ import warnings
 from contextlib import contextmanager
 from typing import cast, Iterable, Iterator, TextIO, TYPE_CHECKING, TypeVar
 
-from .deploy_api import CLIInteractions, UserInteractions
+from .interaction_utils import (
+    CLIInteractions,
+    FatalCommandError,
+    UserInteractions,
+)
 
 if TYPE_CHECKING:
     from sr.comp.raw_compstate import RawCompstate
@@ -38,35 +42,6 @@ T = TypeVar('T')
 
 API_TIMEOUT_SECONDS = 3
 DEPLOY_USER = 'srcomp'
-
-
-class FatalDeployError(RuntimeError):
-    """
-    Something went wrong which means that the deploy cannot continue.
-
-    This a marker exception and callsites should handle their own displaying of
-    a suitable error message. The message passed to this exception will not be
-    shown to the user and is intended for logging.
-    """
-
-    def __init__(self, log_message: str, exit_code: int = 1) -> None:
-        super().__init__(log_message, exit_code)
-        self.log_message = log_message
-        self.exit_code = exit_code
-
-
-@contextmanager
-def make_fatal(
-    interactions: UserInteractions[T],
-    msg: str = '{0}',
-    kind: type[Exception] = Exception,
-) -> Iterator[None]:
-    try:
-        yield
-    except kind as e:
-        msg = msg.format(e)
-        interactions.show_error(msg)
-        raise FatalDeployError(msg, exit_code=1) from e
 
 
 @contextmanager
@@ -110,7 +85,7 @@ def guard_unicode_output(stream: TextIO) -> Iterator[None]:
 
 def query_warn(msg: object, interactions: UserInteractions[T]) -> None:
     if not interactions.query_bool(f"Warning: {msg}. Continue?", False):
-        raise FatalDeployError(f"User rejected warning {msg}", exit_code=1)
+        raise FatalCommandError(f"User rejected warning {msg}", exit_code=1)
 
 
 def ref_compstate(host: str) -> str:
@@ -141,7 +116,7 @@ def deploy_to(
         # revision exists in the target, since this push will simply no-op
         # if it's already present
         revspec = '{0}:refs/heads/deploy-{0}'.format(revision)
-        with make_fatal(interactions, kind=RuntimeError):
+        with interactions.make_fatal(kind=RuntimeError):
             compstate.push(
                 url,
                 revspec,
@@ -166,7 +141,7 @@ def deploy_to(
 
 
 def get_deployments(compstate: RawCompstate, interactions: UserInteractions[T]) -> list[str]:
-    with make_fatal(interactions, "Failed to get deployments from state ({0})."):
+    with interactions.make_fatal("Failed to get deployments from state ({0})."):
         return compstate.deployments
 
 
@@ -260,13 +235,13 @@ def require_no_changes(compstate: RawCompstate, interactions: UserInteractions[T
         interactions.show_info(
             compstate.git(['status'], return_output=True),
         )
-        raise FatalDeployError("Unexpected state changes present", exit_code=1)
+        raise FatalCommandError("Unexpected state changes present", exit_code=1)
 
 
 def require_valid(compstate: RawCompstate, interactions: UserInteractions[T]) -> None:
     from sr.comp.validation import validate
 
-    with make_fatal(interactions, "State cannot be loaded: {0}"):
+    with interactions.make_fatal("State cannot be loaded: {0}"):
         comp = compstate.load()
 
     num_errors = validate(comp)
@@ -293,7 +268,7 @@ def run_deployments(
             # TODO: work out if it makes sense to try to rollback here?
             message = f"Failed to deploy to '{host}' (exit status: {retcode})."
             interactions.show_error(message)
-            raise FatalDeployError(message, exit_code=retcode)
+            raise FatalCommandError(message, exit_code=retcode)
 
     interactions.show_strong_ok("Done")
 
@@ -313,7 +288,7 @@ def command(args: argparse.Namespace) -> None:
 
             run_deployments(args, compstate, hosts, interactions)
 
-        except FatalDeployError as e:
+        except FatalCommandError as e:
             # Callsites are responsible for showing the user a useful message.
             exit(e.exit_code)
 

--- a/sr/comp/cli/deploy.py
+++ b/sr/comp/cli/deploy.py
@@ -40,8 +40,23 @@ API_TIMEOUT_SECONDS = 3
 DEPLOY_USER = 'srcomp'
 
 
+class FatalDeployError(RuntimeError):
+    """
+    Something went wrong which means that the deploy cannot continue.
+
+    This a marker exception and callsites should handle their own displaying of
+    a suitable error message. The message passed to this exception will not be
+    shown to the user and is intended for logging.
+    """
+
+    def __init__(self, log_message: str, exit_code: int = 1) -> None:
+        super().__init__(log_message, exit_code)
+        self.log_message = log_message
+        self.exit_code = exit_code
+
+
 @contextmanager
-def exit_on_exception(
+def make_fatal(
     interactions: UserInteractions[T],
     msg: str = '{0}',
     kind: type[Exception] = Exception,
@@ -49,9 +64,9 @@ def exit_on_exception(
     try:
         yield
     except kind as e:
-        interactions.show_error(msg.format(e))
-        # TODO(PR): interactions exit?
-        exit(1)
+        msg = msg.format(e)
+        interactions.show_error(msg)
+        raise FatalDeployError(msg, exit_code=1) from e
 
 
 @contextmanager
@@ -95,8 +110,7 @@ def guard_unicode_output(stream: TextIO) -> Iterator[None]:
 
 def query_warn(msg: object, interactions: UserInteractions[T]) -> None:
     if not interactions.query_bool(f"Warning: {msg}. Continue?", False):
-        # TODO(PR): interactions exit?
-        exit(1)
+        raise FatalDeployError(f"User rejected warning {msg}", exit_code=1)
 
 
 def ref_compstate(host: str) -> str:
@@ -127,7 +141,7 @@ def deploy_to(
         # revision exists in the target, since this push will simply no-op
         # if it's already present
         revspec = '{0}:refs/heads/deploy-{0}'.format(revision)
-        with exit_on_exception(interactions, kind=RuntimeError):
+        with make_fatal(interactions, kind=RuntimeError):
             compstate.push(
                 url,
                 revspec,
@@ -152,7 +166,7 @@ def deploy_to(
 
 
 def get_deployments(compstate: RawCompstate, interactions: UserInteractions[T]) -> list[str]:
-    with exit_on_exception(interactions, "Failed to get deployments from state ({0})."):
+    with make_fatal(interactions, "Failed to get deployments from state ({0})."):
         return compstate.deployments
 
 
@@ -246,14 +260,13 @@ def require_no_changes(compstate: RawCompstate, interactions: UserInteractions[T
         interactions.show_info(
             compstate.git(['status'], return_output=True),
         )
-        # TODO(PR): interactions exit?
-        exit(1)
+        raise FatalDeployError("Unexpected state changes present", exit_code=1)
 
 
 def require_valid(compstate: RawCompstate, interactions: UserInteractions[T]) -> None:
     from sr.comp.validation import validate
 
-    with exit_on_exception(interactions, "State cannot be loaded: {0}"):
+    with make_fatal(interactions, "State cannot be loaded: {0}"):
         comp = compstate.load()
 
     num_errors = validate(comp)
@@ -278,9 +291,9 @@ def run_deployments(
         retcode = deploy_to(compstate, host, revision, args.verbose, interactions)
         if retcode != 0:
             # TODO: work out if it makes sense to try to rollback here?
-            interactions.show_error(f"Failed to deploy to '{host}' (exit status: {retcode}).")
-            # TODO(PR): interactions exit?
-            exit(retcode)
+            message = f"Failed to deploy to '{host}' (exit status: {retcode})."
+            interactions.show_error(message)
+            raise FatalDeployError(message, exit_code=retcode)
 
     interactions.show_strong_ok("Done")
 
@@ -291,13 +304,18 @@ def command(args: argparse.Namespace) -> None:
     interactions = CLIInteractions()
 
     with guard_unicode_output(sys.stdout), guard_unicode_output(sys.stderr):
-        compstate = RawCompstate(args.compstate, local_only=False)
-        hosts = get_deployments(compstate, interactions)
+        try:
+            compstate = RawCompstate(args.compstate, local_only=False)
+            hosts = get_deployments(compstate, interactions)
 
-        require_no_changes(compstate, interactions)
-        require_valid(compstate, interactions)
+            require_no_changes(compstate, interactions)
+            require_valid(compstate, interactions)
 
-        run_deployments(args, compstate, hosts, interactions)
+            run_deployments(args, compstate, hosts, interactions)
+
+        except FatalDeployError as e:
+            # Callsites are responsible for showing the user a useful message.
+            exit(e.exit_code)
 
 
 def add_options(parser: argparse.ArgumentParser) -> None:

--- a/sr/comp/cli/deploy_api.py
+++ b/sr/comp/cli/deploy_api.py
@@ -1,0 +1,120 @@
+import abc
+import io
+import textwrap
+from collections.abc import Sequence
+from typing import Generic, TypeVar
+
+T = TypeVar('T')
+
+
+BOLD = '\033[1m'
+FAIL = '\033[91m'
+OKBLUE = '\033[94m'
+ENDC = '\033[0m'
+
+
+class UserInteractions(Generic[T], abc.ABC):
+    @abc.abstractmethod
+    def format_buffer(self, buffer: io.StringIO) -> T:
+        raise NotImplementedError(f"{type(self).__name__}.format_buffer")
+
+    @abc.abstractmethod
+    def format_info(self, message: str) -> T:
+        raise NotImplementedError(f"{type(self).__name__}.format_info")
+
+    @abc.abstractmethod
+    def format_strong(self, message: str) -> T:
+        raise NotImplementedError(f"{type(self).__name__}.format_strong")
+
+    @abc.abstractmethod
+    def format_strong_ok(self, message: str) -> T:
+        raise NotImplementedError(f"{type(self).__name__}.format_strong_ok")
+
+    @abc.abstractmethod
+    def format_error(self, message: str) -> T:
+        raise NotImplementedError(f"{type(self).__name__}.format_error")
+
+    @abc.abstractmethod
+    def message(self, message: T) -> None:
+        raise NotImplementedError(f"{type(self).__name__}.message")
+
+    @abc.abstractmethod
+    def get_input(self, message: T) -> str:
+        raise NotImplementedError(f"{type(self).__name__}.get_input")
+
+    def show_buffer(self, buffer: io.StringIO) -> None:
+        self.message(self.format_buffer(buffer))
+
+    def show_info(self, message: str) -> None:
+        self.message(self.format_info(message))
+
+    def show_strong(self, message: str) -> None:
+        self.message(self.format_strong(message))
+
+    def show_strong_ok(self, message: str) -> None:
+        self.message(self.format_strong_ok(message))
+
+    def show_error(self, message: str) -> None:
+        self.message(self.format_error(message))
+
+    def query(
+        self,
+        question: str,
+        options: Sequence[str],
+        default: str | None = None,
+    ) -> str:
+        if default:
+            assert default in options
+
+        options = [o.upper() if o == default else o.lower() for o in options]
+        assert len(set(options)) == len(options)
+        opts = '/'.join(options)
+
+        query = self.format_error(f"{question.rstrip()} [{opts}]: ")
+
+        while True:
+            # Loop until we get a suitable response from the user
+            resp = self.get_input(query).lower()
+
+            if resp in options:
+                return resp
+
+            # If there's a default value, use that
+            if default:
+                return default
+
+    def query_bool(self, question: str, default_val: bool | None = None) -> bool:
+        options = ('y', 'n')
+        if default_val is True:
+            default: str | None = 'y'
+        elif default_val is False:
+            default = 'n'
+        else:
+            default = None
+        return self.query(question, options, default) == 'y'
+
+
+class CLIInteractions(UserInteractions[str]):
+    def format_buffer(self, buffer: io.StringIO) -> str:
+        content = buffer.getvalue().rstrip()
+        if content:
+            content = textwrap.indent(content, '> ')
+        return content
+
+    def format_info(self, message: str) -> str:
+        return message
+
+    def format_strong(self, message: str) -> str:
+        return BOLD + message + ENDC
+
+    def format_strong_ok(self, message: str) -> str:
+        return BOLD + OKBLUE + message + ENDC
+
+    def format_error(self, message: str) -> str:
+        return BOLD + FAIL + message + ENDC
+
+    def message(self, message: str) -> None:
+        print(message)
+
+    def get_input(self, message: str) -> str:
+        return input(message)

--- a/sr/comp/cli/deploy_api.py
+++ b/sr/comp/cli/deploy_api.py
@@ -63,8 +63,10 @@ class UserInteractions(Generic[T], abc.ABC):
         options: Sequence[str],
         default: str | None = None,
     ) -> str:
-        if default:
-            assert default in options
+        if default and default not in options:
+            raise ValueError(
+                f"Default value {default!r} not an available option (options: {options!r})",
+            )
 
         options = [o.upper() if o == default else o.lower() for o in options]
         assert len(set(options)) == len(options)

--- a/sr/comp/cli/fetch.py
+++ b/sr/comp/cli/fetch.py
@@ -13,17 +13,16 @@ import sys
 
 def command(args: argparse.Namespace) -> None:
     from sr.comp.cli.deploy import (
-        BOLD,
-        ENDC,
-        FAIL,
         get_current_state,
         get_deployments,
         ref_compstate,
     )
+    from sr.comp.cli.interaction_utils import BOLD, CLIInteractions, ENDC, FAIL
     from sr.comp.raw_compstate import RawCompstate
 
     compstate = RawCompstate(args.compstate, local_only=False)
-    hosts = get_deployments(compstate)
+    interactions = CLIInteractions()
+    hosts = get_deployments(compstate, interactions)
 
     print("Fetching upstream... ", end="")
     sys.stdout.flush()
@@ -35,7 +34,7 @@ def command(args: argparse.Namespace) -> None:
         sys.stdout.flush()
 
         # In case of error `get_current_state` prints the error and returns `None`.
-        state = get_current_state(host)
+        state = get_current_state(host, interactions)
         print(ENDC, end='')
         sys.stdout.flush()
         if not state:

--- a/sr/comp/cli/fetch.py
+++ b/sr/comp/cli/fetch.py
@@ -16,6 +16,7 @@ def command(args: argparse.Namespace) -> None:
         get_current_state,
         get_deployments,
         ref_compstate,
+        UnableToGetStateError,
     )
     from sr.comp.cli.interaction_utils import BOLD, CLIInteractions, ENDC, FAIL
     from sr.comp.raw_compstate import RawCompstate
@@ -33,12 +34,13 @@ def command(args: argparse.Namespace) -> None:
         print(f"Fetching {host}... {BOLD}{FAIL}", end="")
         sys.stdout.flush()
 
-        # In case of error `get_current_state` prints the error and returns `None`.
-        state = get_current_state(host, interactions)
-        print(ENDC, end='')
-        sys.stdout.flush()
-        if not state:
+        try:
+            state = get_current_state(host, interactions)
+        except UnableToGetStateError:
             continue
+        finally:
+            print(ENDC, end='')
+            sys.stdout.flush()
 
         compstate.fetch(ref_compstate(host), [state], quiet=True)
         print(f"{state} fetched.")

--- a/sr/comp/cli/for_each_match.py
+++ b/sr/comp/cli/for_each_match.py
@@ -21,6 +21,8 @@ import argparse
 import sys
 from typing import Callable, TYPE_CHECKING
 
+from sr.comp.cli.interaction_utils import CLIInteractions
+
 if TYPE_CHECKING:
     from sr.comp.match_period import Match
 
@@ -77,9 +79,8 @@ def command(args: argparse.Namespace) -> None:
 
     from sr.comp.comp import SRComp
 
-    from .deploy import print_fail
-
     compstate = SRComp(args.compstate)
+    interactions = CLIInteractions()
 
     if args.arena:
         if args.arena not in compstate.arenas:
@@ -101,7 +102,7 @@ def command(args: argparse.Namespace) -> None:
                 subprocess.check_call(command)
 
     except subprocess.CalledProcessError as e:
-        print_fail(str(e))
+        interactions.show_error(str(e))
         exit(1)
 
 

--- a/sr/comp/cli/interaction_utils.py
+++ b/sr/comp/cli/interaction_utils.py
@@ -101,15 +101,15 @@ class UserInteractions(Generic[T], abc.ABC):
             if default:
                 return default
 
-    def query_bool(self, question: str, default_val: bool | None = None) -> bool:
+    def query_bool(self, question: str, default: bool | None = None) -> bool:
         options = ('y', 'n')
-        if default_val is True:
-            default: str | None = 'y'
-        elif default_val is False:
-            default = 'n'
+        if default is True:
+            default_str: str | None = 'y'
+        elif default is False:
+            default_str = 'n'
         else:
-            default = None
-        return self.query(question, options, default) == 'y'
+            default_str = None
+        return self.query(question, options, default_str) == 'y'
 
     @contextlib.contextmanager
     def make_fatal(

--- a/sr/comp/cli/interaction_utils.py
+++ b/sr/comp/cli/interaction_utils.py
@@ -1,7 +1,8 @@
 import abc
+import contextlib
 import io
 import textwrap
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import Generic, TypeVar
 
 T = TypeVar('T')
@@ -11,6 +12,21 @@ BOLD = '\033[1m'
 FAIL = '\033[91m'
 OKBLUE = '\033[94m'
 ENDC = '\033[0m'
+
+
+class FatalCommandError(RuntimeError):
+    """
+    Something went wrong which means that the command cannot continue.
+
+    This a marker exception and callsites should handle their own displaying of
+    a suitable error message. The message passed to this exception will not be
+    shown to the user and is intended for logging.
+    """
+
+    def __init__(self, log_message: str, exit_code: int = 1) -> None:
+        super().__init__(log_message, exit_code)
+        self.log_message = log_message
+        self.exit_code = exit_code
 
 
 class UserInteractions(Generic[T], abc.ABC):
@@ -94,6 +110,19 @@ class UserInteractions(Generic[T], abc.ABC):
         else:
             default = None
         return self.query(question, options, default) == 'y'
+
+    @contextlib.contextmanager
+    def make_fatal(
+        self,
+        msg: str = '{0}',
+        kind: type[Exception] = Exception,
+    ) -> Iterator[None]:
+        try:
+            yield
+        except kind as e:
+            msg = msg.format(e)
+            self.show_error(msg)
+            raise FatalCommandError(msg, exit_code=1) from e
 
 
 class CLIInteractions(UserInteractions[str]):

--- a/tests/test_interaction_utils.py
+++ b/tests/test_interaction_utils.py
@@ -4,12 +4,13 @@ import unittest
 from typing import Any
 from unittest import mock
 
-from sr.comp.cli.deploy import query, query_bool
+from sr.comp.cli.interaction_utils import CLIInteractions
 
 
 def mock_get_input(autospec: bool = True, **kwargs: Any) -> mock._patch[mock.Mock]:
-    return mock.patch(
-        'sr.comp.cli.deploy.get_input',
+    return mock.patch.object(
+        CLIInteractions,
+        'get_input',
         autospec=autospec,
         **kwargs,
     )
@@ -20,17 +21,17 @@ class DeployQueryHelpersTests(unittest.TestCase):
 
     @mock_get_input(return_value='nope')
     def test_query_with_default_nope(self, _: object) -> None:
-        res = query('Question?', ('a'), default='a')
+        res = CLIInteractions().query('Question?', ('a'), default='a')
         self.assertEqual('a', res)
 
     @mock_get_input(return_value='a')
     def test_query_with_default_a(self, _: object) -> None:
-        res = query('Question?', ('a', 'b'), default='b')
+        res = CLIInteractions().query('Question?', ('a', 'b'), default='b')
         self.assertEqual('a', res)
 
     @mock_get_input(side_effect=iter(['nope', 'a']))
     def test_query_nope_then_a(self, mocked_get_input: mock.Mock) -> None:
-        res = query('Question?', ('a', 'b'))
+        res = CLIInteractions().query('Question?', ('a', 'b'))
         self.assertEqual('a', res)
 
         self.assertEqual(2, mocked_get_input.call_count)
@@ -39,51 +40,51 @@ class DeployQueryHelpersTests(unittest.TestCase):
 
     @mock_get_input(return_value='y')
     def test_query_bool_True_y(self, _: object) -> None:
-        res = query_bool('Question?', True)
+        res = CLIInteractions().query_bool('Question?', True)
         self.assertTrue(res)
 
     @mock_get_input(return_value='n')
     def test_query_bool_True_n(self, _: object) -> None:
-        res = query_bool('Question?', True)
+        res = CLIInteractions().query_bool('Question?', True)
         self.assertFalse(res)
 
     @mock_get_input(return_value='other')
     def test_query_bool_True_other(self, _: object) -> None:
-        res = query_bool('Question?', True)
+        res = CLIInteractions().query_bool('Question?', True)
         self.assertTrue(res)
 
     # Test `query_bool` false results
 
     @mock_get_input(return_value='y')
     def test_query_bool_False_y(self, _: object) -> None:
-        res = query_bool('Question?', False)
+        res = CLIInteractions().query_bool('Question?', False)
         self.assertTrue(res)
 
     @mock_get_input(return_value='n')
     def test_query_bool_False_n(self, _: object) -> None:
-        res = query_bool('Question?', False)
+        res = CLIInteractions().query_bool('Question?', False)
         self.assertFalse(res)
 
     @mock_get_input(return_value='other')
     def test_query_bool_False_other(self, _: object) -> None:
-        res = query_bool('Question?', False)
+        res = CLIInteractions().query_bool('Question?', False)
         self.assertFalse(res)
 
     # Test `query_bool` without default
 
     @mock_get_input(return_value='y')
     def test_query_bool_no_default_y(self, _: object) -> None:
-        res = query_bool('Question?')
+        res = CLIInteractions().query_bool('Question?')
         self.assertTrue(res)
 
     @mock_get_input(return_value='n')
     def test_query_bool_no_default_n(self, _: object) -> None:
-        res = query_bool('Question?')
+        res = CLIInteractions().query_bool('Question?')
         self.assertFalse(res)
 
     @mock_get_input(side_effect=iter(['other', 'y']))
     def test_query_bool_no_default_other_then_y(self, mocked_get_input: mock.Mock) -> None:
-        res = query_bool('Question?')
+        res = CLIInteractions().query_bool('Question?')
         self.assertTrue(res)
 
         self.assertEqual(2, mocked_get_input.call_count)


### PR DESCRIPTION
This aims to create a path towards running commands non-interactively. This is expected to be most useful for enabling the deploy logic (and related functionalities) to being available under other user interfaces.

For now the only implementation remains CLI focussed, though the pattern here should be generalisable towards others.

Review by commit _may_ be useful, though there are still some commits here which change earlier approaches.